### PR TITLE
Harden packet processing and config validation against memory-safety edge cases

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -232,6 +232,12 @@ int main(void) {
     if ((v = getenv("AWG_S3")) && v[0]) cfg->s3 = parse_int_str(v);
     if ((v = getenv("AWG_S4")) && v[0]) cfg->s4 = parse_int_str(v);
 
+    {
+        const char *cfg_err = NULL;
+        if (config_validate(cfg, &cfg_err) < 0)
+            fatal(cfg_err);
+    }
+
     /* CPS templates I1-I5 */
     const char *inames[] = { "AWG_I1", "AWG_I2", "AWG_I3", "AWG_I4", "AWG_I5" };
     for (int i = 0; i < 5; i++) {

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -24,9 +24,8 @@ static void fill_h4_ring(proxy_t *p) {
             p->h4_ring[i] = v;
         return;
     }
-    int span = (int)(p->cfg->h4.max - p->cfg->h4.min + 1);
     for (int i = 0; i < H4_RING_SIZE; i++)
-        p->h4_ring[i] = p->cfg->h4.min + (uint32_t)fastrand_intn(&p->rng, span);
+        p->h4_ring[i] = hrange_pick(&p->cfg->h4, fastrand_u64(&p->rng));
 }
 
 static inline uint32_t pick_h4(proxy_t *p) {

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -261,6 +261,7 @@ static int send_gso(int fd, struct iovec *iovecs, int count,
 
 int proxy_init(proxy_t *p, awg_config_t *cfg,
                const char *listen_str, const char *remote_str, int src_port) {
+    const char *cfg_err = NULL;
     memset(p, 0, sizeof(*p));
     p->cfg = cfg;
     p->listen_fd = -1;
@@ -268,6 +269,11 @@ int proxy_init(proxy_t *p, awg_config_t *cfg,
     p->signal_fd = -1;
     p->timer_fd = -1;
     p->gso_ok = 1;
+
+    if (config_validate(cfg, &cfg_err) < 0) {
+        log_error2("invalid config: ", cfg_err);
+        return -1;
+    }
 
     /* Parse listen address */
     char host[256];
@@ -348,7 +354,7 @@ int proxy_init(proxy_t *p, awg_config_t *cfg,
     /* recv_s2c: remote socket, connected — no addr needed */
     for (int i = 0; i < BATCH_SIZE; i++) {
         p->recv_s2c.iovecs[i].iov_base = p->recv_s2c.bufs[i] + s2c_headroom;
-        p->recv_s2c.iovecs[i].iov_len = BUF_SIZE + 256 - s2c_headroom;
+        p->recv_s2c.iovecs[i].iov_len = BUF_SIZE + AWG_PACKET_HEADROOM - s2c_headroom;
         p->recv_s2c.msgs[i].msg_hdr.msg_iov = &p->recv_s2c.iovecs[i];
         p->recv_s2c.msgs[i].msg_hdr.msg_iovlen = 1;
     }
@@ -939,7 +945,7 @@ static void *s2c_thread(void *arg) {
 
     int reverse = (p->cfg->mode != AWG_MODE_NORMAL);
     int s2c_headroom = reverse ? p->cfg->s4 : 0;
-    int s2c_buflen = BUF_SIZE + 256 - s2c_headroom;
+    int s2c_buflen = BUF_SIZE + AWG_PACKET_HEADROOM - s2c_headroom;
     int gro_no_coalesce = 0;
 
     while (!atomic_load_explicit(&p->stopped, memory_order_relaxed)) {

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -535,6 +535,10 @@ static void *c2s_thread_normal(void *arg) {
                 gro_no_coalesce = 0;
                 for (int off = 0; off < total && nrecv < BATCH_SIZE; off += seg_size) {
                     int plen = (off + seg_size <= total) ? seg_size : (int)(total - off);
+                    if (plen > BUF_SIZE) {
+                        log_debug("c2s: dropping oversized GRO segment");
+                        continue;
+                    }
                     memcpy(p->recv_c2s.bufs[nrecv] + prefix, p->gro_buf_c2s + off, plen);
                     p->recv_c2s.msgs[nrecv].msg_len = plen;
                     nrecv++;
@@ -543,6 +547,10 @@ static void *c2s_thread_normal(void *arg) {
                 if (++gro_no_coalesce >= 8) {
                     p->gro_enabled_c2s = 0;
                     log_info("c2s: GRO not coalescing, falling back to recvmmsg");
+                }
+                if (total > BUF_SIZE) {
+                    log_debug("c2s: dropping oversized GRO datagram");
+                    continue;
                 }
                 memcpy(p->recv_c2s.bufs[0] + prefix, p->gro_buf_c2s, (int)total);
                 p->recv_c2s.msgs[0].msg_len = (unsigned int)total;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -36,6 +36,22 @@ static inline uint32_t pick_h4(proxy_t *p) {
     return v;
 }
 
+static int checked_mul_size(size_t a, size_t b, size_t *out) {
+    if (a != 0 && b > SIZE_MAX / a)
+        return -1;
+    *out = a * b;
+    return 0;
+}
+
+static int junk_layout_sizes(const awg_config_t *cfg,
+                             size_t *junk_bytes, size_t *junk_sizes_bytes) {
+    if (checked_mul_size((size_t)cfg->jc, (size_t)cfg->jmax, junk_bytes) < 0)
+        return -1;
+    if (checked_mul_size((size_t)cfg->jc, sizeof(int), junk_sizes_bytes) < 0)
+        return -1;
+    return 0;
+}
+
 static int resolve_addr(const char *host, uint16_t port, struct sockaddr_in *addr) {
     memset(addr, 0, sizeof(*addr));
     addr->sin_family = AF_INET;
@@ -309,8 +325,12 @@ int proxy_init(proxy_t *p, awg_config_t *cfg,
 
     /* Pre-allocate junk buffers */
     if (cfg->jc > 0 && cfg->jmax > 0) {
-        p->junk_buf = (uint8_t *)malloc(cfg->jc * cfg->jmax);
-        p->junk_sizes = (int *)malloc(cfg->jc * sizeof(int));
+        size_t junk_bytes;
+        size_t junk_sizes_bytes;
+        if (junk_layout_sizes(cfg, &junk_bytes, &junk_sizes_bytes) < 0)
+            return -1;
+        p->junk_buf = (uint8_t *)malloc(junk_bytes);
+        p->junk_sizes = (int *)malloc(junk_sizes_bytes);
         if (!p->junk_buf || !p->junk_sizes) return -1;
     }
 
@@ -401,12 +421,17 @@ static void send_junk_and_cps_to(proxy_t *p, int fd, struct sockaddr_in *addr) {
         send_packet_to(fd, p->cps_bufs[i], p->cps_lens[i], addr);
 
     if (cfg->jc > 0 && cfg->jmax > 0) {
-        fastrand_fill(&p->rng, p->junk_buf, cfg->jc * cfg->jmax);
+        size_t junk_bytes;
+        size_t junk_sizes_bytes;
+        if (junk_layout_sizes(cfg, &junk_bytes, &junk_sizes_bytes) < 0)
+            return;
+        (void)junk_sizes_bytes;
+        fastrand_fill(&p->rng, p->junk_buf, junk_bytes);
         int njunk = generate_junk(cfg, p->junk_buf, p->junk_sizes);
-        int off = 0;
+        size_t off = 0;
         for (int i = 0; i < njunk; i++) {
             send_packet_to(fd, p->junk_buf + off, p->junk_sizes[i], addr);
-            off += p->junk_sizes[i];
+            off += (size_t)p->junk_sizes[i];
         }
     }
 }
@@ -422,12 +447,17 @@ static void send_junk_and_cps(proxy_t *p, int fd) {
 
     /* Junk packets */
     if (cfg->jc > 0 && cfg->jmax > 0) {
-        fastrand_fill(&p->rng, p->junk_buf, cfg->jc * cfg->jmax);
+        size_t junk_bytes;
+        size_t junk_sizes_bytes;
+        if (junk_layout_sizes(cfg, &junk_bytes, &junk_sizes_bytes) < 0)
+            return;
+        (void)junk_sizes_bytes;
+        fastrand_fill(&p->rng, p->junk_buf, junk_bytes);
         int njunk = generate_junk(cfg, p->junk_buf, p->junk_sizes);
-        int off = 0;
+        size_t off = 0;
         for (int i = 0; i < njunk; i++) {
             send_packet(fd, p->junk_buf + off, p->junk_sizes[i]);
-            off += p->junk_sizes[i];
+            off += (size_t)p->junk_sizes[i];
         }
     }
 }

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -8,7 +8,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
-#define BUF_SIZE       1500
+#define BUF_SIZE       AWG_PACKET_BUF_SIZE
 #define BATCH_SIZE     32
 #define H4_RING_SIZE   4096
 #define GRO_BUF_SIZE   65536
@@ -56,7 +56,7 @@ typedef struct {
 
     /* Batch I/O buffers — c2s direction */
     struct {
-        uint8_t bufs[BATCH_SIZE][BUF_SIZE + 256];
+        uint8_t bufs[BATCH_SIZE][BUF_SIZE + AWG_PACKET_HEADROOM];
         struct mmsghdr msgs[BATCH_SIZE];
         struct iovec iovecs[BATCH_SIZE];
         struct sockaddr_in addrs[BATCH_SIZE];
@@ -69,7 +69,7 @@ typedef struct {
 
     /* Batch I/O buffers — s2c direction (non-GRO path) */
     struct {
-        uint8_t bufs[BATCH_SIZE][BUF_SIZE + 256];
+        uint8_t bufs[BATCH_SIZE][BUF_SIZE + AWG_PACKET_HEADROOM];
         struct mmsghdr msgs[BATCH_SIZE];
         struct iovec iovecs[BATCH_SIZE];
     } recv_s2c;

--- a/src/test_transform.c
+++ b/src/test_transform.c
@@ -403,6 +403,40 @@ static void test_hrange_pick_contains(void) {
     }
 }
 
+static void test_config_validate_accepts_safe_limits(void) {
+    awg_config_t cfg = make_test_config();
+    const char *err = "unexpected";
+
+    cfg.s1 = AWG_PACKET_BUF_SIZE - WG_INIT_SIZE;
+    cfg.s2 = AWG_PACKET_BUF_SIZE - WG_RESP_SIZE;
+    cfg.s3 = AWG_PACKET_BUF_SIZE - WG_COOKIE_SIZE;
+    cfg.s4 = AWG_PACKET_HEADROOM;
+
+    ASSERT_EQ(config_validate(&cfg, &err), 0);
+    ASSERT(err == NULL);
+}
+
+static void test_config_validate_rejects_unsafe_padding(void) {
+    awg_config_t cfg = make_test_config();
+    const char *err = NULL;
+
+    cfg.s1 = AWG_PACKET_BUF_SIZE - WG_INIT_SIZE + 1;
+    ASSERT_EQ(config_validate(&cfg, &err), -1);
+    ASSERT(err != NULL);
+
+    cfg = make_test_config();
+    err = NULL;
+    cfg.s4 = AWG_PACKET_HEADROOM + 1;
+    ASSERT_EQ(config_validate(&cfg, &err), -1);
+    ASSERT(err != NULL);
+
+    cfg = make_test_config();
+    err = NULL;
+    cfg.s2 = -1;
+    ASSERT_EQ(config_validate(&cfg, &err), -1);
+    ASSERT(err != NULL);
+}
+
 /* 21. Outbound cookie with S3 */
 static void test_outbound_cookie_with_s3(void) {
     awg_config_t cfg = make_test_config();
@@ -1147,6 +1181,8 @@ int main(void) {
     RUN_TEST(no_padding_s2_zero);
     RUN_TEST(outbound_too_short);
     RUN_TEST(hrange_pick_contains);
+    RUN_TEST(config_validate_accepts_safe_limits);
+    RUN_TEST(config_validate_rejects_unsafe_padding);
     RUN_TEST(outbound_cookie_with_s3);
     RUN_TEST(outbound_transport_with_s4);
     RUN_TEST(inbound_scanning_s3);

--- a/src/test_transform.c
+++ b/src/test_transform.c
@@ -440,6 +440,17 @@ static void test_config_validate_rejects_unsafe_padding(void) {
     ASSERT(err != NULL);
 }
 
+static void test_config_validate_rejects_overlapping_hranges(void) {
+    awg_config_t cfg = make_test_config();
+    const char *err = NULL;
+
+    cfg.h1 = (hrange_t){100, 200};
+    cfg.h2 = (hrange_t){200, 300};
+
+    ASSERT_EQ(config_validate(&cfg, &err), -1);
+    ASSERT(err != NULL);
+}
+
 /* 21. Outbound cookie with S3 */
 static void test_outbound_cookie_with_s3(void) {
     awg_config_t cfg = make_test_config();
@@ -1186,6 +1197,7 @@ int main(void) {
     RUN_TEST(hrange_pick_contains);
     RUN_TEST(config_validate_accepts_safe_limits);
     RUN_TEST(config_validate_rejects_unsafe_padding);
+    RUN_TEST(config_validate_rejects_overlapping_hranges);
     RUN_TEST(outbound_cookie_with_s3);
     RUN_TEST(outbound_transport_with_s4);
     RUN_TEST(inbound_scanning_s3);

--- a/src/test_transform.c
+++ b/src/test_transform.c
@@ -401,6 +401,9 @@ static void test_hrange_pick_contains(void) {
         uint32_t v = hrange_pick(&r4, (uint64_t)i * 0x9E3779B97F4A7C15ULL);
         ASSERT(hrange_contains(&r4, v));
     }
+
+    hrange_t r5 = {0u, UINT32_MAX};
+    ASSERT_EQ(hrange_pick(&r5, 0x1122334455667788ULL), 0x55667788u);
 }
 
 static void test_config_validate_accepts_safe_limits(void) {

--- a/src/test_transform.c
+++ b/src/test_transform.c
@@ -395,6 +395,12 @@ static void test_hrange_pick_contains(void) {
     ASSERT(hrange_contains(&r3, 20));
     ASSERT(!hrange_contains(&r3, 9));
     ASSERT(!hrange_contains(&r3, 21));
+
+    hrange_t r4 = {1000200001u, 4294967295u};
+    for (int i = 0; i < 1000; i++) {
+        uint32_t v = hrange_pick(&r4, (uint64_t)i * 0x9E3779B97F4A7C15ULL);
+        ASSERT(hrange_contains(&r4, v));
+    }
 }
 
 /* 21. Outbound cookie with S3 */

--- a/src/transform.c
+++ b/src/transform.c
@@ -4,8 +4,30 @@
 #include <string.h>
 
 /* Static buffer for handshake packets when headroom is insufficient.
- * Handshakes are rare (1-2 per connection), so static is fine. Max: S_max + 148 */
-static __thread uint8_t hs_buf[1500];
+ * Handshakes are rare (1-2 per connection), so static is fine. */
+static __thread uint8_t hs_buf[AWG_PACKET_BUF_SIZE];
+
+int config_validate(const awg_config_t *cfg, const char **err_msg) {
+    if (cfg->s1 < 0 || cfg->s1 > AWG_PACKET_BUF_SIZE - WG_INIT_SIZE) {
+        *err_msg = "AWG_S1: must be between 0 and 1352";
+        return -1;
+    }
+    if (cfg->s2 < 0 || cfg->s2 > AWG_PACKET_BUF_SIZE - WG_RESP_SIZE) {
+        *err_msg = "AWG_S2: must be between 0 and 1408";
+        return -1;
+    }
+    if (cfg->s3 < 0 || cfg->s3 > AWG_PACKET_BUF_SIZE - WG_COOKIE_SIZE) {
+        *err_msg = "AWG_S3: must be between 0 and 1436";
+        return -1;
+    }
+    if (cfg->s4 < 0 || cfg->s4 > AWG_PACKET_HEADROOM) {
+        *err_msg = "AWG_S4: must be between 0 and 256";
+        return -1;
+    }
+
+    *err_msg = NULL;
+    return 0;
+}
 
 void config_compute(awg_config_t *cfg) {
     static const uint8_t z[32] = {0};

--- a/src/transform.c
+++ b/src/transform.c
@@ -7,6 +7,10 @@
  * Handshakes are rare (1-2 per connection), so static is fine. */
 static __thread uint8_t hs_buf[AWG_PACKET_BUF_SIZE];
 
+static int hrange_overlaps(const hrange_t *a, const hrange_t *b) {
+    return a->min <= b->max && b->min <= a->max;
+}
+
 int config_validate(const awg_config_t *cfg, const char **err_msg) {
     if (cfg->s1 < 0 || cfg->s1 > AWG_PACKET_BUF_SIZE - WG_INIT_SIZE) {
         *err_msg = "AWG_S1: must be between 0 and 1352";
@@ -22,6 +26,15 @@ int config_validate(const awg_config_t *cfg, const char **err_msg) {
     }
     if (cfg->s4 < 0 || cfg->s4 > AWG_PACKET_HEADROOM) {
         *err_msg = "AWG_S4: must be between 0 and 256";
+        return -1;
+    }
+    if (hrange_overlaps(&cfg->h1, &cfg->h2) ||
+        hrange_overlaps(&cfg->h1, &cfg->h3) ||
+        hrange_overlaps(&cfg->h1, &cfg->h4) ||
+        hrange_overlaps(&cfg->h2, &cfg->h3) ||
+        hrange_overlaps(&cfg->h2, &cfg->h4) ||
+        hrange_overlaps(&cfg->h3, &cfg->h4)) {
+        *err_msg = "AWG_H1..AWG_H4: ranges must not overlap";
         return -1;
     }
 

--- a/src/transform.h
+++ b/src/transform.h
@@ -16,6 +16,10 @@
 #define WG_COOKIE_SIZE    64
 #define WG_TRANSPORT_MIN  32
 
+/* Shared fixed buffer sizes used by the proxy data paths */
+#define AWG_PACKET_BUF_SIZE 1500
+#define AWG_PACKET_HEADROOM 256
+
 /* H range for v2 */
 typedef struct {
     uint32_t min, max;
@@ -103,6 +107,9 @@ typedef struct {
 
 /* Compute MAC1 keys and fast-path flags. Call after setting all config fields. */
 void config_compute(awg_config_t *cfg);
+
+/* Validate config values that participate in buffer sizing and layout. */
+int config_validate(const awg_config_t *cfg, const char **err_msg);
 
 /* Transform outbound WG->AWG. Returns output pointer and length.
  * buf has dataoff bytes of headroom before the packet data.

--- a/src/transform.h
+++ b/src/transform.h
@@ -27,7 +27,8 @@ typedef struct {
 
 static inline uint32_t hrange_pick(const hrange_t *r, uint64_t rand_val) {
     if (r->min == r->max) return r->min;
-    return r->min + (uint32_t)(rand_val % (uint64_t)(r->max - r->min + 1));
+    uint64_t span = (uint64_t)r->max - (uint64_t)r->min + 1u;
+    return r->min + (uint32_t)(rand_val % span);
 }
 
 static inline int hrange_contains(const hrange_t *r, uint32_t v) {


### PR DESCRIPTION
  This PR fixes several memory-safety and correctness issues in the packet transform/proxy paths, with a focus on size validation and safe handling of edge-case ranges.

  Changes:

  - Fix wide H4 range selection so large configured ranges are handled correctly.
  - Validate configured padding/headroom sizes (S1-S4) up front to prevent invalid buffer offsets and fallback-buffer overflows.
  - Use checked allocation sizing for junk buffers to avoid integer overflow in jc * jmax style calculations.
  - Drop oversized GRO datagrams/segments before copying them into fixed packet buffers.
  - Handle full-width H1-H4 ranges safely, including 0-4294967295, by doing span arithmetic in 64-bit space.
  - Reject overlapping H1-H4 ranges during configuration validation.


  AI-assisted: Codex (GPT-5)