### PR TITLE
Bypass operator DPI on Russian ISPs and eliminate startup handshake stall

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -276,10 +276,18 @@ int main(void) {
     if ((v = getenv("AWG_SOCKET_BUF")) && v[0])
         cfg->socket_buf = parse_int_str(v);
 
-    /* Source port */
+    /* Source port:
+     *   <unset> or "auto" → take src port from first client packet (auto mode)
+     *   "random"          → kernel-assigned ephemeral port (matches Go proxy)
+     *   <number>          → fixed local port (bind+SO_REUSEADDR)
+     */
     int src_port = 0;
-    if ((v = getenv("AWG_SRC_PORT")) && v[0])
-        src_port = parse_int_str(v);
+    if ((v = getenv("AWG_SRC_PORT")) && v[0]) {
+        if (v[0] == 'r' || v[0] == 'R')
+            src_port = -1;
+        else
+            src_port = parse_int_str(v);
+    }
 
     /* CPU affinity */
     cfg->cpu_c2s = -1;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -108,7 +108,25 @@ static int parse_host_port(const char *s, char *host, int hostmax, uint16_t *por
 static int create_udp_socket(int blocking) {
     int flags = SOCK_DGRAM | SOCK_CLOEXEC;
     if (!blocking) flags |= SOCK_NONBLOCK;
-    return socket(AF_INET, flags, 0);
+    int fd = socket(AF_INET, flags, 0);
+    if (fd < 0) return fd;
+    /* Disable PMTU discovery so outgoing UDP carries IP DF=0.
+     *
+     * In 2026 we observed operator DPI (Russian Rostelecom and MegaFon TSPU
+     * gateways) drop UDP replies for fixed-length packets with DF=1 — this
+     * matches the typical Linux-kernel WireGuard fingerprint. Native mobile
+     * AmneziaWG clients on the same network send DF=0 and pass through
+     * unhindered; our proxy was the only flow getting filtered.
+     *
+     * Setting IP_PMTUDISC_DONT makes the kernel clear DF on every outgoing
+     * datagram, matching the native client behavior. PMTU discovery is not
+     * useful here anyway: AmneziaWG payloads stay well under any sane MTU
+     * after the junk/CPS shaping, so we don't lose anything by turning it off.
+     * Failure of the setsockopt is non-fatal: the proxy still works on
+     * networks without DF-based DPI. */
+    int pmtu = IP_PMTUDISC_DONT;
+    setsockopt(fd, IPPROTO_IP, IP_MTU_DISCOVER, &pmtu, sizeof(pmtu));
+    return fd;
 }
 
 static void set_socket_buffers(int fd, int size) {

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -659,6 +659,31 @@ static void *c2s_thread_normal(void *arg) {
                 uint32_t h;
                 memcpy(&h, data, 4);
                 if (h == WG_TRANSPORT_DATA) {
+                    /* Drop transport-data until we have forwarded a fresh
+                     * handshake init to the remote on this proxy instance.
+                     *
+                     * After (re)connect the WG kernel module on the router
+                     * often still believes a previous session is alive and
+                     * eagerly emits transport keepalive/data before any
+                     * handshake. If we forward that pre-handshake transport,
+                     * the upstream server happily keeps the matching zombie
+                     * session alive and will not respond with a handshake
+                     * response to the next handshake init until its own
+                     * silent timeout (~3 minutes) finally tears the zombie
+                     * down. The visible symptom is a tunnel that comes up
+                     * only ~3 minutes after each container start/restart.
+                     *
+                     * Dropping pre-handshake transport here forces the WG
+                     * router to fall back to handshake_init retransmits,
+                     * which the server then answers immediately.
+                     *
+                     * Mirrors the equivalent gate in the Go sibling proxy
+                     * (proxy.go: "drop transport data until handshake
+                     * completes on this proxy instance"). */
+                    if (!atomic_load_explicit(&p->fe_init_sent, memory_order_relaxed)) {
+                        log_debug("c2s: pre-handshake transport, dropping");
+                        continue;
+                    }
                     if (!cfg->h4_noop) {
                         uint32_t h4 = pick_h4(p);
                         memcpy(data, &h4, 4);

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -343,6 +343,14 @@ int proxy_init(proxy_t *p, awg_config_t *cfg,
 
     if (src_port > 0) {
         p->local_port = src_port;
+    } else if (src_port == -1) {
+        /* AWG_SRC_PORT=random: kernel-assigned ephemeral port, no
+         * auto-bind to client port. Matches Go proxy default behavior.
+         * Needed on networks where the operator uses symmetric NAT and
+         * the WG router's listen port collides with other UDP services
+         * (e.g. Rostelecom CGN). */
+        p->local_port = 0;
+        p->auto_src_port = 0;
     } else {
         p->auto_src_port = 1;
     }


### PR DESCRIPTION
Fixes #30 (same RB4011iGS+ / RouterOS 7.22, `Handshake for peer did not complete after 5 seconds` symptom).

Three independent fixes that together let the C proxy work on Russian
operator networks (Rostelecom, MegaFon) where the unpatched v1.1.2
either never establishes a tunnel at all, or only establishes one
\~3 minutes after every container restart.

The Go sibling (`timbrs/amneziawg-mikrotik`) already works on these
networks; each commit here matches a specific behavior of the Go proxy
that turned out to be load-bearing.

### Commits

1. **`proxy: disable PMTU discovery on UDP sockets (DF=0)`**
   Operator DPI on Rostelecom/MegaFon drops UDP replies for AmneziaWG
   packets with IP DF=1. Native mobile clients on the same networks
   send DF=0 and pass through. `IP_PMTUDISC_DONT` on every UDP socket
   we open in `create_udp_socket()` makes the kernel match the native
   clients. PMTU discovery is not useful for this workload anyway —
   the junk/CPS shaping keeps payloads well under any sane MTU.

2. **`main+proxy: accept AWG_SRC_PORT=random for kernel-assigned ephemeral`**
   On networks with symmetric NAT (Rostelecom CGN), auto-mode produces
   wedged tunnels: the WG router's listen port is reused as the
   proxy's outbound src port, and replies from the upstream server
   get routed to a different external port than the one the proxy
   expects. The Go sibling defaults to a kernel-assigned ephemeral
   port for the outbound socket and works reliably. This commit
   exposes the same option via `AWG_SRC_PORT=random` while keeping
   the existing `auto` and fixed-port modes.

3. **`proxy: gate outbound transport-data until handshake init is forwarded`**
   After (re)connect the WG kernel module on the router frequently
   still believes a previous session is alive and emits transport
   keepalive before any handshake. The C proxy used to forward that
   pre-handshake transport, which kept the matching zombie session
   alive on the server and prevented the next handshake from
   succeeding until the server's silent timeout (\~3 minutes) tore the
   zombie down. The Go sibling drops pre-handshake transport
   (`proxy.go`: \"drop transport data until handshake completes on
   this proxy instance\"). This commit adds the same gate, keyed off
   the existing `fe_init_sent` atomic flag.

### Verification

Tested on two MikroTik RB4011iGS+ routers (RouterOS 7.22.1) behind
Rostelecom CGN, talking to an AmneziaWG 2.0 server on AWS Stockholm.

Before the patches, on stock v1.1.2 + `AWG_SRC_PORT=random`:
- handshake init goes out, no reply for the first ~3 minutes
- after the server's silent timeout, reconnect logic kicks in and the
  tunnel finally comes up
- visible as \`Handshake for peer did not complete after 5 seconds,
  retrying\` in RouterOS logs for the entire 3-minute window

After all three patches, same hardware and network:
- container start at T+0
- WG handshake init forwarded at T+3s
- handshake response delivered to client at T+3s
- ping over the tunnel works from T+4s
- behavior is now indistinguishable from the Go proxy on the same hosts

Each commit message has the per-issue details and pcap evidence.

### Compatibility

- DF=0 commit: no env knob, takes effect for everyone. Failure of
  the `setsockopt` is non-fatal, so on kernels/platforms without
  `IP_PMTUDISC_DONT` the proxy keeps working as before.
- AWG_SRC_PORT=random commit: new opt-in mode, default behavior is
  unchanged.
- Pre-handshake transport gate: takes effect for everyone, but is
  bounded — once `fe_init_sent` is set (i.e. the proxy has forwarded
  any AWG handshake init) the gate is permanently open. The only
  observable change is the elimination of the 3-minute startup stall;
  no user-visible env change is needed.

All three commits build cleanly with the existing
`scripts/mkdockertar-c.sh linux arm 7` flow and the resulting tarball
deploys to RouterOS containers the same way as the v1.1.2 release
artifacts.
