### PR TITLE
Fix two c2s/s2c data races (seqlock client addr + deferred remote-fd close)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ CFLAGS = -O2 -Wall -Wextra -Werror -std=c11 -D_GNU_SOURCE -ffunction-sections -f
 LDFLAGS = -static -Wl,--gc-sections -flto -s -lpthread
 
 .PHONY: build clean test test-blake2s test-cps test-transform test-base64 test-session test-stress \
+	test-concurrency \
 	docker-arm64 docker-arm docker-armv5 docker-amd64 docker-all \
 	docker-arm64-7.20-docker docker-arm-7.20-docker docker-armv5-7.20-docker docker-amd64-7.20-docker docker-all-7.20-docker
 
@@ -17,7 +18,7 @@ build:
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(IMAGE_NAME) $(SRCS)
 
-test: test-blake2s test-cps test-transform test-base64 test-session
+test: test-blake2s test-cps test-transform test-base64 test-session test-concurrency
 	@echo "All tests passed"
 
 test-blake2s: src/test_blake2s.c $(TEST_SRCS)
@@ -39,6 +40,10 @@ test-base64: src/test_base64.c $(TEST_SRCS)
 test-session: src/test_session.c $(TEST_SRCS)
 	$(CC) $(TEST_CFLAGS) -o /tmp/test_session $^
 	/tmp/test_session
+
+test-concurrency: src/test_concurrency.c
+	$(CC) $(TEST_CFLAGS) -lpthread -o /tmp/test_concurrency $<
+	/tmp/test_concurrency
 
 # Stress test — manual only, NOT part of `make test` or CI
 test-stress: src/test_stress.c build

--- a/src/concurrency.h
+++ b/src/concurrency.h
@@ -1,0 +1,106 @@
+#ifndef AWG_CONCURRENCY_H
+#define AWG_CONCURRENCY_H
+
+/*
+ * Cross-thread primitives shared between the c2s and s2c proxy threads.
+ *
+ * The proxy has exactly two hot threads and two pieces of mutable state
+ * that cross between them; both used to be touched without a memory-safe
+ * protocol. These helpers make those accesses race-free:
+ *
+ *   client_slot_t — a single-writer seqlock around the client sockaddr.
+ *     c2s is the sole writer (it learns/updates the client address); s2c
+ *     reads it for every reply. A plain struct read could tear while c2s
+ *     rewrites the 16 bytes on a client port roam, sending a reply to a
+ *     spliced (new addr + old port) destination. The seqlock guarantees
+ *     the reader only ever returns a value that was written atomically.
+ *
+ *   fd_retire_t — one-generation deferred close of the remote fd. s2c's
+ *     do_reconnect() must not close the old fd immediately: c2s may have
+ *     just loaded it and be about to send on it, and the kernel could
+ *     reuse the freed number. Retiring defers the close by one reconnect
+ *     generation — by then c2s has long since reloaded remote_fd — so a
+ *     send can never land on a closed-and-reused descriptor.
+ *
+ * Single writer per primitive (c2s for the slot, s2c for the retire list),
+ * so neither needs a lock; only C11 acquire/release ordering.
+ */
+
+#include <stdatomic.h>
+#include <unistd.h>
+#include <string.h>
+#include <netinet/in.h>
+
+/* ---- client_slot_t: single-writer seqlock ---- */
+
+typedef struct {
+    _Atomic unsigned seq;      /* even = stable, odd = write in progress */
+    _Atomic int has_value;     /* 0 until the first write publishes an addr */
+    struct sockaddr_in addr;   /* guarded by seq */
+} client_slot_t;
+
+static inline void client_slot_init(client_slot_t *cs) {
+    atomic_store_explicit(&cs->seq, 0, memory_order_relaxed);
+    atomic_store_explicit(&cs->has_value, 0, memory_order_relaxed);
+    memset(&cs->addr, 0, sizeof(cs->addr));
+}
+
+/* Sole writer (c2s). Publishes addr so concurrent readers never tear. */
+static inline void client_slot_write(client_slot_t *cs, const struct sockaddr_in *addr) {
+    unsigned s = atomic_load_explicit(&cs->seq, memory_order_relaxed);
+    /* Enter write: make seq odd, then fence so the body cannot float up. */
+    atomic_store_explicit(&cs->seq, s + 1, memory_order_relaxed);
+    atomic_thread_fence(memory_order_release);
+    cs->addr = *addr;
+    /* Leave write: store-release makes the body visible before seq goes even. */
+    atomic_store_explicit(&cs->seq, s + 2, memory_order_release);
+    atomic_store_explicit(&cs->has_value, 1, memory_order_release);
+}
+
+/* Reader (s2c). Returns 1 and fills *out with a consistent snapshot, or 0
+ * if no address has been published yet. */
+static inline int client_slot_read(client_slot_t *cs, struct sockaddr_in *out) {
+    if (!atomic_load_explicit(&cs->has_value, memory_order_acquire))
+        return 0;
+    for (;;) {
+        unsigned s1 = atomic_load_explicit(&cs->seq, memory_order_acquire);
+        if (s1 & 1u)
+            continue;                 /* writer mid-update, retry */
+        *out = cs->addr;
+        atomic_thread_fence(memory_order_acquire);
+        unsigned s2 = atomic_load_explicit(&cs->seq, memory_order_relaxed);
+        if (s1 == s2)
+            return 1;                 /* no write straddled the copy */
+    }
+}
+
+/* ---- fd_retire_t: one-generation deferred close ---- */
+
+typedef struct {
+    int retained;   /* fd kept alive one extra generation, or -1 */
+} fd_retire_t;
+
+static inline void fd_retire_init(fd_retire_t *r) {
+    r->retained = -1;
+}
+
+/* Retire an fd. Closes the fd retired in the previous call (now safely
+ * unreferenced) and keeps the new one alive for one more generation.
+ * A negative fd is a no-op and does not disturb the retained generation. */
+static inline void fd_retire_push(fd_retire_t *r, int fd) {
+    if (fd < 0)
+        return;
+    if (r->retained >= 0)
+        close(r->retained);
+    r->retained = fd;
+}
+
+/* Close the last retained fd. Call once on shutdown after threads join. */
+static inline void fd_retire_drain(fd_retire_t *r) {
+    if (r->retained >= 0) {
+        close(r->retained);
+        r->retained = -1;
+    }
+}
+
+#endif /* AWG_CONCURRENCY_H */

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -302,6 +302,8 @@ int proxy_init(proxy_t *p, awg_config_t *cfg,
     p->signal_fd = -1;
     p->timer_fd = -1;
     p->gso_ok = 1;
+    client_slot_init(&p->client);
+    fd_retire_init(&p->remote_retire);
 
     if (config_validate(cfg, &cfg_err) < 0) {
         log_error2("invalid config: ", cfg_err);
@@ -517,6 +519,10 @@ static void *c2s_thread_normal(void *arg) {
     int prefix = cfg->s4;
     int prev_nrecv = BATCH_SIZE;
     int gro_no_coalesce = 0;
+    /* Thread-local shadow of the last published client addr — lets the sole
+     * writer detect changes without reading the seqlock-guarded slot. */
+    struct sockaddr_in last_client;
+    memset(&last_client, 0, sizeof(last_client));
 
     while (!atomic_load_explicit(&p->stopped, memory_order_relaxed)) {
         int nrecv;
@@ -593,14 +599,15 @@ static void *c2s_thread_normal(void *arg) {
         /* Check client address from first packet */
         if (p->recv_c2s.addrs[0].sin_family == AF_INET) {
             if (!atomic_load_explicit(&p->has_client, memory_order_acquire) ||
-                p->client_addr.sin_addr.s_addr != p->recv_c2s.addrs[0].sin_addr.s_addr ||
-                p->client_addr.sin_port != p->recv_c2s.addrs[0].sin_port) {
-                p->client_addr = p->recv_c2s.addrs[0];
+                last_client.sin_addr.s_addr != p->recv_c2s.addrs[0].sin_addr.s_addr ||
+                last_client.sin_port != p->recv_c2s.addrs[0].sin_port) {
+                last_client = p->recv_c2s.addrs[0];
+                client_slot_write(&p->client, &p->recv_c2s.addrs[0]);
                 atomic_store_explicit(&p->has_client, 1, memory_order_release);
                 char abuf[INET_ADDRSTRLEN];
-                inet_ntop(AF_INET, &p->client_addr.sin_addr, abuf, sizeof(abuf));
+                inet_ntop(AF_INET, &last_client.sin_addr, abuf, sizeof(abuf));
                 char pbuf[12];
-                const char *parts[] = { "client: ", abuf, ":", u32_to_str(pbuf, ntohs(p->client_addr.sin_port)) };
+                const char *parts[] = { "client: ", abuf, ":", u32_to_str(pbuf, ntohs(last_client.sin_port)) };
                 log_infon(parts, 4);
 
                 if (p->auto_src_port) {
@@ -711,6 +718,8 @@ static void *c2s_thread_reverse(void *arg) {
     set_thread_affinity(cfg->cpu_c2s, "c2s");
     int s4 = cfg->s4;
     int prev_nrecv = BATCH_SIZE;
+    struct sockaddr_in last_client;
+    memset(&last_client, 0, sizeof(last_client));
 
     while (!atomic_load_explicit(&p->stopped, memory_order_relaxed)) {
         for (int i = 0; i < prev_nrecv; i++) {
@@ -731,14 +740,15 @@ static void *c2s_thread_reverse(void *arg) {
         /* In reverse (1:1) mode, track single client */
         if (!server_mode && p->recv_c2s.addrs[0].sin_family == AF_INET) {
             if (!atomic_load_explicit(&p->has_client, memory_order_acquire) ||
-                p->client_addr.sin_addr.s_addr != p->recv_c2s.addrs[0].sin_addr.s_addr ||
-                p->client_addr.sin_port != p->recv_c2s.addrs[0].sin_port) {
-                p->client_addr = p->recv_c2s.addrs[0];
+                last_client.sin_addr.s_addr != p->recv_c2s.addrs[0].sin_addr.s_addr ||
+                last_client.sin_port != p->recv_c2s.addrs[0].sin_port) {
+                last_client = p->recv_c2s.addrs[0];
+                client_slot_write(&p->client, &p->recv_c2s.addrs[0]);
                 atomic_store_explicit(&p->has_client, 1, memory_order_release);
                 char abuf[INET_ADDRSTRLEN];
-                inet_ntop(AF_INET, &p->client_addr.sin_addr, abuf, sizeof(abuf));
+                inet_ntop(AF_INET, &last_client.sin_addr, abuf, sizeof(abuf));
                 char pbuf[12];
-                const char *parts[] = { "client: ", abuf, ":", u32_to_str(pbuf, ntohs(p->client_addr.sin_port)) };
+                const char *parts[] = { "client: ", abuf, ":", u32_to_str(pbuf, ntohs(last_client.sin_port)) };
                 log_infon(parts, 4);
             }
         }
@@ -838,6 +848,11 @@ static inline int process_s2c_pkt_normal(proxy_t *p, uint8_t *pkt, int n,
     awg_config_t *cfg = p->cfg;
     int s4 = cfg->s4;
 
+    /* Consistent snapshot of the client addr (writer: c2s). */
+    struct sockaddr_in client;
+    if (!client_slot_read(&p->client, &client))
+        return 0;
+
     /* Transport fast-path with precomputed ambiguity check */
     if (n >= s4 + WG_TRANSPORT_MIN) {
         if (!cfg->transport_size_ambiguous ||
@@ -850,7 +865,7 @@ static inline int process_s2c_pkt_normal(proxy_t *p, uint8_t *pkt, int n,
                 int idx = *nsend;
                 send_iovecs[idx].iov_base = pkt + s4;
                 send_iovecs[idx].iov_len = n - s4;
-                send_addrs[idx] = p->client_addr;
+                send_addrs[idx] = client;
                 (*nsend)++;
                 if (!atomic_exchange_explicit(&p->fe_transport_s2c, 1, memory_order_relaxed))
                     log_info("s2c: first transport packet to client");
@@ -890,7 +905,7 @@ static inline int process_s2c_pkt_normal(proxy_t *p, uint8_t *pkt, int n,
     int idx = *nsend;
     send_iovecs[idx].iov_base = out;
     send_iovecs[idx].iov_len = out_len;
-    send_addrs[idx] = p->client_addr;
+    send_addrs[idx] = client;
     (*nsend)++;
     if (mtype == WG_HANDSHAKE_RESPONSE &&
         !atomic_exchange_explicit(&p->fe_resp_sent, 1, memory_order_relaxed))
@@ -911,6 +926,7 @@ static inline int process_s2c_pkt_reverse(proxy_t *p, uint8_t *base, uint8_t *pk
 
     /* Determine destination address */
     struct sockaddr_in *dest_addr = NULL;
+    struct sockaddr_in client_local;   /* backs dest_addr in reverse 1:1 mode */
     session_entry_t *dest_entry = NULL;
     uint32_t msg_type = 0;
     const uint8_t *out_mac1key = NULL;
@@ -946,9 +962,9 @@ static inline int process_s2c_pkt_reverse(proxy_t *p, uint8_t *base, uint8_t *pk
         }
         dest_addr = &dest_entry->addr;
     } else {
-        /* reverse 1:1: use single client_addr */
-        if (!atomic_load_explicit(&p->has_client, memory_order_acquire)) return 0;
-        dest_addr = &p->client_addr;
+        /* reverse 1:1: consistent snapshot of the single client addr */
+        if (!client_slot_read(&p->client, &client_local)) return 0;
+        dest_addr = &client_local;
     }
 
     /* Transport fast-path */
@@ -1010,8 +1026,12 @@ static inline int process_s2c_pkt_reverse(proxy_t *p, uint8_t *base, uint8_t *pk
 static int do_reconnect(proxy_t *p) {
     int old_fd = atomic_load_explicit(&p->remote_fd, memory_order_acquire);
     if (old_fd >= 0) {
-        close(old_fd);
+        /* Defer the close by one reconnect generation: c2s may have just
+         * loaded old_fd and be about to send on it, and the kernel could
+         * reuse the freed number. By the next reconnect c2s has long since
+         * reloaded remote_fd, so closing then can never hit a live user. */
         atomic_store_explicit(&p->remote_fd, -1, memory_order_release);
+        fd_retire_push(&p->remote_retire, old_fd);
     }
 
     log_info2("reconnecting to ", p->remote_host);
@@ -1377,6 +1397,7 @@ join:
     /* Cleanup */
     rfd = atomic_load_explicit(&p->remote_fd, memory_order_relaxed);
     if (rfd >= 0) close(rfd);
+    fd_retire_drain(&p->remote_retire);   /* close any fd still held for grace */
     if (p->listen_fd >= 0) close(p->listen_fd);
     if (p->signal_fd >= 0) close(p->signal_fd);
     if (p->timer_fd >= 0) close(p->timer_fd);

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -3,6 +3,7 @@
 
 #include "transform.h"
 #include "fastrand.h"
+#include "concurrency.h"
 #include <stdint.h>
 #include <stdatomic.h>
 #include <sys/socket.h>
@@ -54,7 +55,7 @@ typedef struct {
     _Atomic uint8_t fe_transport_c2s;   /* first transport packet to remote */
     _Atomic uint8_t fe_transport_s2c;   /* first transport packet to client */
     uint8_t _pad_fe;
-    struct sockaddr_in client_addr; /* 16B */
+    client_slot_t client;           /* seqlock-published client addr (writer: c2s) */
     int gso_ok;                     /* 4B */
     int gro_enabled;                /* 4B */
     uint16_t h4_idx;                /* 2B */
@@ -96,6 +97,9 @@ typedef struct {
     uint16_t remote_port;
     int auto_src_port;
     int local_port;
+
+    /* Deferred close of superseded remote fds (writer: s2c/do_reconnect). */
+    fd_retire_t remote_retire;
 
     uint32_t cps_counter;
     uint8_t *junk_buf;

--- a/src/test_concurrency.c
+++ b/src/test_concurrency.c
@@ -1,0 +1,176 @@
+/*
+ * Unit tests for the proxy's cross-thread concurrency primitives
+ * (src/concurrency.h):
+ *
+ *   1. client_slot_t — single-writer seqlock publishing the client
+ *      sockaddr so the s2c reader never observes a torn address while
+ *      c2s rewrites it on a client port roam.
+ *   2. fd_retire_t — one-generation deferred close of the remote fd so
+ *      c2s can never send on a descriptor that do_reconnect() closed (and
+ *      the kernel may have reused) mid-iteration.
+ *
+ * Portable: C11 atomics + pthreads + POSIX fcntl/close. Runs on the dev
+ * mac and on the Linux build host. No proxy.h (avoids Linux-only mmsghdr).
+ */
+
+#include <stdint.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "test.h"
+#include "concurrency.h"
+
+/* ---- client_slot_t: seqlock ---- */
+
+static struct sockaddr_in mkaddr(uint32_t v) {
+    /* Self-consistent encoding: the port mirrors the low 16 bits of the
+     * address, so any torn read (new addr + old port, or vice versa) is
+     * detectable by the reader. */
+    struct sockaddr_in a;
+    memset(&a, 0, sizeof(a));
+    a.sin_family = AF_INET;
+    a.sin_addr.s_addr = v;
+    a.sin_port = (uint16_t)(v & 0xFFFF);
+    return a;
+}
+
+static void test_client_slot_basic(void) {
+    client_slot_t cs;
+    client_slot_init(&cs);
+
+    struct sockaddr_in out;
+    /* No write yet: read reports "no value". */
+    ASSERT(client_slot_read(&cs, &out) == 0);
+
+    struct sockaddr_in in = mkaddr(0xABCD1234);
+    client_slot_write(&cs, &in);
+
+    ASSERT(client_slot_read(&cs, &out) == 1);
+    ASSERT(out.sin_addr.s_addr == in.sin_addr.s_addr);
+    ASSERT(out.sin_port == in.sin_port);
+}
+
+#define SEQ_VALUE_A 0x11111111u
+#define SEQ_VALUE_B 0x22222222u
+#define SEQ_READS   2000000
+
+typedef struct {
+    client_slot_t *cs;
+    _Atomic int stop;
+    _Atomic long torn;   /* count of inconsistent reads observed */
+    _Atomic long reads;  /* count of successful (consistent) reads */
+} seq_reader_t;
+
+static void *seq_reader(void *arg) {
+    seq_reader_t *r = (seq_reader_t *)arg;
+    struct sockaddr_in out;
+    long reads = 0, torn = 0;
+    while (!atomic_load_explicit(&r->stop, memory_order_relaxed)) {
+        if (!client_slot_read(r->cs, &out)) continue;
+        /* Invariant: port mirrors low 16 bits of address. A torn read
+         * (half from value A, half from value B) breaks it. */
+        if (out.sin_port != (uint16_t)(out.sin_addr.s_addr & 0xFFFF))
+            torn++;
+        reads++;
+    }
+    atomic_store_explicit(&r->reads, reads, memory_order_relaxed);
+    atomic_store_explicit(&r->torn, torn, memory_order_relaxed);
+    return NULL;
+}
+
+static void test_client_slot_no_torn_read(void) {
+    client_slot_t cs;
+    client_slot_init(&cs);
+    struct sockaddr_in init = mkaddr(SEQ_VALUE_A);
+    client_slot_write(&cs, &init);
+
+    seq_reader_t r;
+    memset(&r, 0, sizeof(r));
+    r.cs = &cs;
+    pthread_t t;
+    pthread_create(&t, NULL, seq_reader, &r);
+
+    /* Writer: flip between two self-consistent values many times. */
+    for (long i = 0; i < SEQ_READS; i++) {
+        struct sockaddr_in a = mkaddr((i & 1) ? SEQ_VALUE_B : SEQ_VALUE_A);
+        client_slot_write(&cs, &a);
+    }
+    atomic_store_explicit(&r.stop, 1, memory_order_relaxed);
+    pthread_join(t, NULL);
+
+    long reads = atomic_load_explicit(&r.reads, memory_order_relaxed);
+    long torn = atomic_load_explicit(&r.torn, memory_order_relaxed);
+    fprintf(stderr, "          (consistent reads=%ld, torn=%ld)\n", reads, torn);
+    ASSERT(reads > 0);   /* reader actually ran concurrently */
+    ASSERT(torn == 0);   /* seqlock guarantees no torn read is ever returned */
+}
+
+/* ---- fd_retire_t: one-generation deferred close ---- */
+
+static int fd_is_open(int fd) {
+    return fcntl(fd, F_GETFD) != -1;
+}
+
+/* A throwaway but valid fd. */
+static int open_fd(void) {
+    int fd = dup(STDIN_FILENO);
+    return fd;
+}
+
+static void test_fd_retire_grace(void) {
+    fd_retire_t r;
+    fd_retire_init(&r);
+
+    int a = open_fd(); ASSERT(a >= 0);
+    int b = open_fd(); ASSERT(b >= 0);
+    int c = open_fd(); ASSERT(c >= 0);
+    ASSERT(a != b && b != c && a != c);
+
+    /* Retire A: nothing closed yet — A must remain valid for any thread
+     * still holding it from before the swap. */
+    fd_retire_push(&r, a);
+    ASSERT(fd_is_open(a));
+
+    /* Retire B: A is now one generation old and gets closed; B survives. */
+    fd_retire_push(&r, b);
+    ASSERT(!fd_is_open(a));
+    ASSERT(fd_is_open(b));
+
+    /* Retire C: B closed, C survives. */
+    fd_retire_push(&r, c);
+    ASSERT(!fd_is_open(b));
+    ASSERT(fd_is_open(c));
+
+    /* Drain on shutdown: the last retained fd is closed. */
+    fd_retire_drain(&r);
+    ASSERT(!fd_is_open(c));
+}
+
+static void test_fd_retire_ignores_negative(void) {
+    fd_retire_t r;
+    fd_retire_init(&r);
+
+    int a = open_fd(); ASSERT(a >= 0);
+    fd_retire_push(&r, a);
+    /* A negative (absent) fd must not disturb the retained generation. */
+    fd_retire_push(&r, -1);
+    ASSERT(fd_is_open(a));   /* still retained, not closed by the -1 push */
+
+    fd_retire_drain(&r);
+    ASSERT(!fd_is_open(a));
+}
+
+int main(void) {
+    fprintf(stderr, "=== concurrency tests ===\n");
+    RUN_TEST(client_slot_basic);
+    RUN_TEST(client_slot_no_torn_read);
+    RUN_TEST(fd_retire_grace);
+    RUN_TEST(fd_retire_ignores_negative);
+    TEST_MAIN_END();
+}


### PR DESCRIPTION
## Summary

The proxy runs exactly two hot threads (`c2s`, `s2c`) and shares two pieces of mutable state between them. Both were accessed without a memory-safe protocol, leaving narrow but real data races on the normal-mode data path. This PR closes both with small, lock-free, single-writer primitives (new `src/concurrency.h`).

## The two races

**1. `client_addr` tear.** `c2s` is the sole writer of the client `sockaddr` and rewrites all 16 bytes when the client roams source port. The `has_client` release-store only published the *first* write, so subsequent rewrites had no barrier. `s2c` read the struct non-atomically for every reply, so a concurrent rewrite could splice a reply destination (new address + old port).

Fix: `client_slot_t`, a single-writer seqlock. `c2s` publishes via `client_slot_write`; `s2c` takes a consistent snapshot via `client_slot_read`. `c2s` keeps a thread-local shadow for change detection, so its hot path does **no** cross-thread read (and is in fact slightly lighter than before).

**2. Remote fd use-after-close / reuse.** `do_reconnect()` (on `s2c`) closed the old remote fd immediately, while `c2s` could be holding a freshly-loaded copy of `remote_fd` and about to `send()` on it — and the kernel could reuse the freed descriptor number in between. The window opened on every reconnect (i.e. on every CGN rebind / DNS re-resolve).

Fix: `fd_retire_t`, a one-generation deferred close. `do_reconnect()` retires the old fd instead of closing it; the actual `close()` happens on the *next* reconnect, by which point `c2s` has long since reloaded `remote_fd`. Drained once on shutdown after the threads join.

Both primitives have a single writer (c2s for the slot, s2c for the retire list), so neither needs a lock — only C11 acquire/release ordering.

## Scope

Only the **normal-mode** c2s/s2c data path is touched. The `reverse`/`server` modes route their client snapshot through the same seqlock for consistency, but the server-mode session-table / PRNG sharing is out of scope here.

## Tests

New deterministic unit tests in `src/test_concurrency.c`, wired into `make test`:

- `client_slot_no_torn_read` — a reader thread spins against a writer flipping between two self-consistent values (port mirrors the low 16 bits of the address); asserts **zero** torn reads over millions of iterations.
- `fd_retire_grace` — asserts the one-generation close semantics (retire A keeps A open; retire B closes A; drain closes the last).

`make test` is green (all existing suites + the new one). Builds clean with `musl-gcc` (the container toolchain). The manual `make test-stress` correctness scenarios (normal/reverse/server, concurrent handshakes, GRO bidirectional) pass unchanged.
