### PR TITLE
Паддинг/junk/CPS из ядерного CSPRNG + алиасинг общего буфера в reverse/server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,22 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 IMAGE_NAME = awg-proxy
 BUILD_DIR = ../builds
 
-SRCS = src/main.c src/proxy.c src/transform.c src/blake2s.c src/chacha20.c src/cps.c src/fastrand.c src/base64.c src/log.c
+SRCS = src/main.c src/proxy.c src/transform.c src/blake2s.c src/chacha20.c src/cps.c src/fastrand.c src/csprng.c src/base64.c src/log.c
 CFLAGS = -O2 -Wall -Wextra -Werror -std=c11 -D_GNU_SOURCE -ffunction-sections -fdata-sections -flto -DVERSION=\"$(VERSION)\"
 LDFLAGS = -static -Wl,--gc-sections -flto -s -lpthread
 
-.PHONY: build clean test test-blake2s test-chacha20 test-cps test-transform test-base64 test-session test-dns test-state test-gro test-mtu test-stress \
+.PHONY: build clean test test-blake2s test-chacha20 test-cps test-csprng test-transform test-base64 test-session test-dns test-state test-gro test-mtu test-stress \
 	docker-arm64 docker-arm docker-armv5 docker-amd64 docker-all \
 	docker-arm64-7.20-docker docker-arm-7.20-docker docker-armv5-7.20-docker docker-amd64-7.20-docker docker-all-7.20-docker
 
-TEST_SRCS = src/blake2s.c src/chacha20.c src/cps.c src/transform.c src/fastrand.c src/base64.c src/log.c
+TEST_SRCS = src/blake2s.c src/chacha20.c src/cps.c src/transform.c src/fastrand.c src/csprng.c src/base64.c src/log.c
 TEST_CFLAGS = -g -Wall -Wextra -Werror -std=c11 -D_GNU_SOURCE
 
 build:
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(IMAGE_NAME) $(SRCS)
 
-test: test-blake2s test-chacha20 test-cps test-transform test-base64 test-session test-dns test-state test-gro test-mtu
+test: test-blake2s test-chacha20 test-cps test-csprng test-transform test-base64 test-session test-dns test-state test-gro test-mtu
 	@echo "All tests passed"
 
 test-blake2s: src/test_blake2s.c $(TEST_SRCS)
@@ -31,6 +31,10 @@ test-chacha20: src/test_chacha20.c $(TEST_SRCS)
 test-cps: src/test_cps.c $(TEST_SRCS)
 	$(CC) $(TEST_CFLAGS) -o /tmp/test_cps $^
 	/tmp/test_cps
+
+test-csprng: src/test_csprng.c $(TEST_SRCS)
+	$(CC) $(TEST_CFLAGS) -o /tmp/test_csprng $^ -lpthread
+	/tmp/test_csprng
 
 test-transform: src/test_transform.c $(TEST_SRCS)
 	$(CC) $(TEST_CFLAGS) -o /tmp/test_transform $^

--- a/src/cps.c
+++ b/src/cps.c
@@ -1,5 +1,5 @@
 #include "cps.h"
-#include "fastrand.h"
+#include "csprng.h"
 #include <string.h>
 #include <time.h>
 
@@ -154,9 +154,11 @@ int cps_max_size(const cps_template_t *tmpl) {
 
 int cps_generate(const cps_template_t *tmpl, uint32_t counter, uint8_t *buf, int bufsize) {
     int off = 0;
-    fastrand_t rng;
-    fastrand_init(&rng, counter ^ 0xDEADBEEF);
 
+    /* The random segments go on the wire raw, so they come from the CSPRNG —
+     * as in the reference (device/obf_rand.go, obf_randchars.go: rand.Read).
+     * They used to be xorshift64 seeded with counter ^ constant, which made the
+     * bytes of the Nth CPS packet identical on every run of every instance. */
     for (int i = 0; i < tmpl->nseg; i++) {
         const cps_segment_t *seg = &tmpl->segs[i];
         switch (seg->kind) {
@@ -167,13 +169,14 @@ int cps_generate(const cps_template_t *tmpl, uint32_t counter, uint8_t *buf, int
             break;
         case CPS_RANDOM:
             if (off + seg->size > bufsize) return off;
-            fastrand_fill(&rng, buf + off, seg->size);
+            csprng_bytes(buf + off, (size_t)seg->size);
             off += seg->size;
             break;
         case CPS_RANDOM_CHARS:
             if (off + seg->size > bufsize) return off;
+            csprng_bytes(buf + off, (size_t)seg->size);
             for (int j = 0; j < seg->size; j++)
-                buf[off + j] = chars52[fastrand_intn(&rng, CHARS52_LEN)];
+                buf[off + j] = chars52[buf[off + j] % CHARS52_LEN];
             off += seg->size;
             break;
         case CPS_ZEROS:
@@ -183,8 +186,9 @@ int cps_generate(const cps_template_t *tmpl, uint32_t counter, uint8_t *buf, int
             break;
         case CPS_RANDOM_DIGITS:
             if (off + seg->size > bufsize) return off;
+            csprng_bytes(buf + off, (size_t)seg->size);
             for (int j = 0; j < seg->size; j++)
-                buf[off + j] = '0' + fastrand_intn(&rng, 10);
+                buf[off + j] = (uint8_t)('0' + buf[off + j] % 10);
             off += seg->size;
             break;
         case CPS_TIMESTAMP: {

--- a/src/csprng.c
+++ b/src/csprng.c
@@ -1,0 +1,124 @@
+#include "csprng.h"
+#include "log.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#include <sys/random.h>
+#endif
+
+#define POOL_SIZE 4096
+
+/* Everything per-thread: no locks on the hot path, and two file descriptors at
+ * worst (the proxy runs two packet threads). */
+static __thread uint8_t pool[POOL_SIZE];
+static __thread size_t pool_left;    /* unread bytes at the tail of pool[] */
+static __thread int urandom_fd = -1;
+static __thread int urandom_tried;
+
+/* Raw kernel entropy. Returns 0 on success, -1 if nothing could be read. */
+static int kernel_bytes(uint8_t *out, size_t len) {
+    size_t done = 0;
+
+#if defined(__linux__) && defined(SYS_getrandom)
+    /* getrandom(2) needs no file descriptor (Linux 3.17+); older kernels return
+     * ENOSYS and we fall through to /dev/urandom. */
+    while (done < len) {
+        long r = syscall(SYS_getrandom, out + done, len - done, 0);
+        if (r < 0) {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+        if (r == 0)
+            break;
+        done += (size_t)r;
+    }
+    if (done == len)
+        return 0;
+    done = 0;                     /* partial result is discarded, not reused */
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+    while (done < len) {
+        size_t chunk = len - done;
+        if (chunk > 256)          /* getentropy() caps at 256 bytes per call */
+            chunk = 256;
+        if (getentropy(out + done, chunk) != 0) {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+        done += chunk;
+    }
+    if (done == len)
+        return 0;
+    done = 0;
+#endif
+
+    if (urandom_fd < 0 && !urandom_tried) {
+        urandom_tried = 1;
+        urandom_fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+    }
+    if (urandom_fd < 0)
+        return -1;
+
+    while (done < len) {
+        ssize_t r = read(urandom_fd, out + done, len - done);
+        if (r < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        if (r == 0)               /* EOF on /dev/urandom: the source is gone */
+            return -1;
+        done += (size_t)r;
+    }
+    return 0;
+}
+
+int csprng_init(void) {
+    uint8_t probe[8];
+
+    /* Verify we can actually get bytes: a container without /dev and without
+     * getrandom(2) must fail loudly at startup instead of emitting predictable
+     * padding for the lifetime of the tunnel. */
+    return kernel_bytes(probe, sizeof(probe));
+}
+
+void csprng_bytes(uint8_t *out, size_t len) {
+    /* Large request: straight from the kernel, no point buffering it. */
+    if (len >= POOL_SIZE / 4) {
+        if (kernel_bytes(out, len) != 0)
+            goto no_entropy;
+        return;
+    }
+
+    if (pool_left < len) {
+        if (kernel_bytes(pool, POOL_SIZE) != 0)
+            goto no_entropy;
+        pool_left = POOL_SIZE;
+    }
+
+    {
+        uint8_t *src = pool + (POOL_SIZE - pool_left);
+        memcpy(out, src, len);
+        /* Wipe what was handed out: a later read of this memory must not give
+         * away padding and nonces that are already on the wire. */
+        memset(src, 0, len);
+        pool_left -= len;
+    }
+    return;
+
+no_entropy:
+    /* The source worked at startup (csprng_init) and has now disappeared, which
+     * a healthy kernel does not do. Carrying on would put a predictable pattern
+     * on the wire for as long as the tunnel lives, and that cannot be taken back
+     * once a censor has seen it. Fail closed and let the supervisor restart us. */
+    log_error("csprng: entropy source unavailable at runtime, aborting");
+    abort();
+}

--- a/src/csprng.h
+++ b/src/csprng.h
@@ -1,0 +1,24 @@
+#ifndef AWG_CSPRNG_H
+#define AWG_CSPRNG_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Cryptographically strong random bytes, buffered from the kernel.
+ *
+ * fastrand (xorshift64) is fine for picking H values or junk sizes, but not for
+ * anything an observer sees raw: the packet padding is such a place. With AWG 3.0
+ * it doubles as the ChaCha20 nonce, and a predictable padding both fingerprints
+ * the proxy and leaks the generator state. amneziawg-go uses crypto/rand here.
+ *
+ * Bytes are drawn from a per-thread pool refilled from the kernel, so the syscall
+ * cost is amortized over hundreds of packets. */
+
+/* Open/verify the entropy source. 0 = ok, -1 = unavailable. Call once at startup
+ * for an early, clear failure; csprng_bytes() also initializes lazily. */
+int csprng_init(void);
+
+/* Fill out[0..len) with random bytes. Never fails once csprng_init() succeeded. */
+void csprng_bytes(uint8_t *out, size_t len);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 #include "cps.h"
 #include "log.h"
 #include "base64.h"
+#include "csprng.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -308,6 +309,13 @@ int main(void) {
     const char *v;
     awg_config_t *cfg = &g_config;
     memset(cfg, 0, sizeof(*cfg));
+
+    /* Padding, junk and CPS bodies all come from the kernel CSPRNG. If there is
+     * no entropy source (a container built without /dev and on a kernel without
+     * getrandom(2)), fail here rather than put a predictable pattern on the
+     * wire for the lifetime of the tunnel. */
+    if (csprng_init() < 0)
+        fatal("no entropy source: getrandom(2) and /dev/urandom both unavailable");
 
     /* Required env vars */
     const char *listen_str = getenv_required("AWG_LISTEN", &errs);

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1,6 +1,7 @@
 #include "proxy.h"
 #include "cps.h"
 #include "log.h"
+#include "csprng.h"
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -1042,18 +1043,16 @@ int proxy_init(proxy_t *p, awg_config_t *cfg,
     /* src_port < 0 ("random"): local_port stays 0, no bind — the kernel
      * picks a fresh ephemeral port on every connect */
 
-    /* Init PRNG */
+    /* Init PRNG. fastrand still picks H values and junk sizes; what goes on the
+     * wire byte for byte comes from csprng_bytes(). The old seeding read
+     * /dev/urandom without checking the result and fell back to the address of
+     * a static struct in a static non-PIE binary — a constant, so a container
+     * without /dev/urandom replayed the same stream after every restart. */
     uint64_t seed;
-    int ufd = open("/dev/urandom", O_RDONLY);
-    if (ufd >= 0) {
-        read(ufd, &seed, 8);
-        close(ufd);
-    } else {
-        seed = (uint64_t)(uintptr_t)p ^ 0xDEADBEEFCAFEULL;
-    }
+    csprng_bytes((uint8_t *)&seed, sizeof(seed));
     fastrand_init(&p->rng, seed);
-    /* The two directions must never emit the same padding bytes at the same
-     * time, so they run independent streams from independent seeds. */
+    /* The two directions must never emit the same values at the same time, so
+     * they run independent streams from independent seeds. */
     fastrand_init(&p->rng_c2s, seed ^ 0x9E3779B97F4A7C15ULL);
     fastrand_init(&p->rng_s2c, seed ^ 0xBF58476D1CE4E5B9ULL);
 
@@ -1339,7 +1338,7 @@ static void send_junk_and_cps_to(proxy_t *p, int fd, cliaddr_t *addr) {
         if (junk_layout_sizes(cfg, &junk_bytes, &junk_sizes_bytes) < 0)
             return;
         (void)junk_sizes_bytes;
-        fastrand_fill(&p->rng_s2c, p->junk_buf, junk_bytes);
+        csprng_bytes(p->junk_buf, junk_bytes);
         int njunk = generate_junk(cfg, p->junk_buf, p->junk_sizes);
         size_t off = 0;
         for (int i = 0; i < njunk; i++) {
@@ -1368,7 +1367,7 @@ static void send_junk_and_cps(proxy_t *p, int fd) {
         if (junk_layout_sizes(cfg, &junk_bytes, &junk_sizes_bytes) < 0)
             return;
         (void)junk_sizes_bytes;
-        fastrand_fill(&p->rng_c2s, p->junk_buf, junk_bytes);
+        csprng_bytes(p->junk_buf, junk_bytes);
         int njunk = generate_junk(cfg, p->junk_buf, p->junk_sizes);
         size_t off = 0;
         for (int i = 0; i < njunk; i++) {
@@ -1603,7 +1602,7 @@ static void *c2s_thread_normal(void *arg) {
                     int total = n;
                     if (s4 > 0) {
                         base = data - s4;
-                        fastrand_fill(&p->rng_c2s, base, (size_t)s4);
+                        csprng_bytes(base, (size_t)s4);
                         total = s4 + n;
                     }
                     if (hp)
@@ -2002,7 +2001,7 @@ static inline int process_s2c_pkt_reverse(proxy_t *p, uint8_t *base, uint8_t *pk
             int total = n;
             if (pr->s4 > 0 && prefix >= pr->s4) {
                 out = pkt - pr->s4;
-                fastrand_fill(&p->rng_s2c, out, (size_t)pr->s4);
+                csprng_bytes(out, (size_t)pr->s4);
                 total = pr->s4 + n;
                 if (pr->hp_on)
                     chacha20_xor(cfg->hp_key, out, pkt, AWG_HP_TRANSPORT_HDR);

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -2059,6 +2059,15 @@ static inline int process_s2c_pkt_reverse(proxy_t *p, uint8_t *base, uint8_t *pk
         return 1;
     }
 
+    /* If the transform fell back to its shared buffer — here the headroom is
+     * only max_s4, so every handshake with S1/S2/S3 above that lands there —
+     * the next packet of the batch overwrites it before sendmmsg runs, and two
+     * peers rekeying in one batch each get the other's packet. Send it now. */
+    if (transform_is_shared_buf(out)) {
+        send_packet_to(p->listen_fd, out, out_len, dest_addr);
+        return 1;
+    }
+
     int idx = *nsend;
     send_iovecs[idx].iov_base = out;
     send_iovecs[idx].iov_len = out_len;

--- a/src/test_cps.c
+++ b/src/test_cps.c
@@ -77,6 +77,52 @@ static void test_generate_random_digits(void) {
     }
 }
 
+/* The random segments used to come from xorshift64 seeded with
+ * counter ^ constant, so the Nth CPS packet after start was byte-identical on
+ * every run of every instance — a ready-made static signature on the packet
+ * whose whole job is to look like someone else's protocol. Same counter must
+ * now give different bytes. */
+static void test_random_segments_differ_for_same_counter(void) {
+    cps_template_t tmpl;
+    uint8_t a[64], b[64];
+
+    ASSERT_EQ(cps_parse("<b 0xf1e2><r 16>", &tmpl), 0);
+    ASSERT_EQ(cps_generate(&tmpl, 0, a, sizeof(a)), 18);
+    ASSERT_EQ(cps_generate(&tmpl, 0, b, sizeof(b)), 18);
+    ASSERT_EQ(a[0], 0xf1);
+    ASSERT_EQ(b[0], 0xf1);           /* static part still fixed */
+    ASSERT(memcmp(a + 2, b + 2, 16) != 0);
+
+    /* Same for the character and digit forms. */
+    ASSERT_EQ(cps_parse("<rc 24>", &tmpl), 0);
+    ASSERT_EQ(cps_generate(&tmpl, 7, a, sizeof(a)), 24);
+    ASSERT_EQ(cps_generate(&tmpl, 7, b, sizeof(b)), 24);
+    ASSERT(memcmp(a, b, 24) != 0);
+
+    ASSERT_EQ(cps_parse("<rd 24>", &tmpl), 0);
+    ASSERT_EQ(cps_generate(&tmpl, 7, a, sizeof(a)), 24);
+    ASSERT_EQ(cps_generate(&tmpl, 7, b, sizeof(b)), 24);
+    ASSERT(memcmp(a, b, 24) != 0);
+}
+
+/* And the bytes must not be a step of the old generator applied to their own
+ * first eight — the check a censor would run. */
+static void test_random_segment_is_not_a_prng_chain(void) {
+    cps_template_t tmpl;
+    uint8_t buf[64];
+    ASSERT_EQ(cps_parse("<r 32>", &tmpl), 0);
+
+    for (int round = 0; round < 16; round++) {
+        ASSERT_EQ(cps_generate(&tmpl, (uint32_t)round, buf, sizeof(buf)), 32);
+        uint64_t v;
+        memcpy(&v, buf, 8);
+        v ^= v << 13;
+        v ^= v >> 7;
+        v ^= v << 17;
+        ASSERT(memcmp(buf + 8, &v, 8) != 0);
+    }
+}
+
 static void test_parse_mixed_rc_rd(void) {
     cps_template_t tmpl;
     uint8_t buf[64];
@@ -309,5 +355,7 @@ int main(void) {
     RUN_TEST(parse_d_tags);
     RUN_TEST(randchars_letters_only);
     RUN_TEST(timestamp_big_endian);
+    RUN_TEST(random_segments_differ_for_same_counter);
+    RUN_TEST(random_segment_is_not_a_prng_chain);
     TEST_MAIN_END();
 }

--- a/src/test_csprng.c
+++ b/src/test_csprng.c
@@ -1,0 +1,121 @@
+/* The CSPRNG behind everything that goes on the wire raw: S padding, junk
+ * bodies, CPS random segments. These tests do not judge the kernel's entropy —
+ * they pin the properties of this wrapper that a caller depends on: it fills
+ * exactly what it was asked for, it does not repeat, and it keeps working
+ * across the internal pool boundary and for requests larger than the pool. */
+#include <stdint.h>
+#include <string.h>
+#include <pthread.h>
+#include "test.h"
+#include "csprng.h"
+
+#define POOL_SIZE 4096            /* mirrors csprng.c */
+
+static void test_init_succeeds(void) {
+    ASSERT_EQ(csprng_init(), 0);
+}
+
+/* Two draws of any size must differ. 32 bytes: a collision on healthy entropy
+ * is not something that happens before the sun burns out. */
+static void test_draws_differ(void) {
+    uint8_t a[32], b[32];
+    memset(a, 0, sizeof(a));
+    memset(b, 0, sizeof(b));
+    csprng_bytes(a, sizeof(a));
+    csprng_bytes(b, sizeof(b));
+    ASSERT(memcmp(a, b, sizeof(a)) != 0);
+}
+
+/* The one property the old fastrand path failed: the second eight bytes must
+ * not be a step of xorshift64 applied to the first eight. */
+static void test_not_an_xorshift_chain(void) {
+    for (int i = 0; i < 64; i++) {
+        uint8_t buf[16];
+        csprng_bytes(buf, sizeof(buf));
+        uint64_t v;
+        memcpy(&v, buf, 8);
+        v ^= v << 13;
+        v ^= v >> 7;
+        v ^= v << 17;
+        ASSERT(memcmp(buf + 8, &v, 8) != 0);
+    }
+}
+
+/* Exactly len bytes are written and nothing beyond them is touched. */
+static void test_writes_exact_length(void) {
+    for (int len = 1; len <= 64; len++) {
+        uint8_t buf[128];
+        memset(buf, 0x5A, sizeof(buf));
+        csprng_bytes(buf, (size_t)len);
+        for (int i = len; i < 128; i++)
+            ASSERT_EQ(buf[i], 0x5A);
+    }
+}
+
+/* Requests keep working across the internal pool refill: 12 bytes at a time is
+ * the header-protection nonce size, and the pool boundary must not repeat or
+ * short-fill anything. Collect a window of draws around the refill and check
+ * they are all distinct. */
+static void test_crosses_pool_boundary(void) {
+    enum { N = POOL_SIZE / 12 + 8, LEN = 12 };
+    static uint8_t seen[N][LEN];
+
+    for (int i = 0; i < N; i++) {
+        memset(seen[i], 0, LEN);
+        csprng_bytes(seen[i], LEN);
+    }
+    for (int i = 0; i < N; i++) {
+        int all_zero = 1;
+        for (int k = 0; k < LEN; k++)
+            if (seen[i][k]) { all_zero = 0; break; }
+        ASSERT(!all_zero);
+        for (int j = i + 1; j < N; j++)
+            ASSERT(memcmp(seen[i], seen[j], LEN) != 0);
+    }
+}
+
+/* A request larger than the pool bypasses it and must still be filled whole. */
+static void test_large_request(void) {
+    static uint8_t big[POOL_SIZE * 2];
+    memset(big, 0, sizeof(big));
+    csprng_bytes(big, sizeof(big));
+
+    /* No 64-byte run of zeros: a partial fill would leave one. */
+    int zero_run = 0;
+    for (size_t i = 0; i < sizeof(big); i++) {
+        zero_run = big[i] ? 0 : zero_run + 1;
+        ASSERT(zero_run < 64);
+    }
+}
+
+/* The pool is per-thread, so two threads must not hand out the same bytes. */
+static void *thread_draw(void *arg) {
+    csprng_bytes((uint8_t *)arg, 64);
+    return NULL;
+}
+
+static void test_threads_get_distinct_bytes(void) {
+    uint8_t a[64], b[64];
+    pthread_t ta, tb;
+    memset(a, 0, sizeof(a));
+    memset(b, 0, sizeof(b));
+
+    ASSERT_EQ(pthread_create(&ta, NULL, thread_draw, a), 0);
+    ASSERT_EQ(pthread_create(&tb, NULL, thread_draw, b), 0);
+    pthread_join(ta, NULL);
+    pthread_join(tb, NULL);
+
+    ASSERT(memcmp(a, b, sizeof(a)) != 0);
+}
+
+int main(void) {
+    fprintf(stderr, "=== csprng tests ===\n");
+    RUN_TEST(init_succeeds);
+    RUN_TEST(draws_differ);
+    RUN_TEST(not_an_xorshift_chain);
+    RUN_TEST(writes_exact_length);
+    RUN_TEST(crosses_pool_boundary);
+    RUN_TEST(large_request);
+    RUN_TEST(threads_get_distinct_bytes);
+    TEST_MAIN_END();
+}

--- a/src/test_stress.c
+++ b/src/test_stress.c
@@ -435,7 +435,19 @@ static void make_wg_init(uint8_t *buf, uint32_t sender_index) {
         buf[i] = (uint8_t)(i ^ (sender_index & 0xFF));
 }
 
-/* make_wg_response not needed — proxy doesn't validate response crypto */
+/* WG handshake response: type, sender_index, receiver_index. The proxy routes
+ * it by receiver_index and does not validate the crypto, so the rest is filler
+ * keyed on sender_index — that is what tells two responses apart on arrival. */
+static void make_wg_response(uint8_t *buf, uint32_t sender_index,
+                             uint32_t receiver_index) {
+    memset(buf, 0, WG_RESP_SIZE);
+    uint32_t t = WG_HANDSHAKE_RESPONSE;
+    memcpy(buf, &t, 4);
+    memcpy(buf + 4, &sender_index, 4);
+    memcpy(buf + 8, &receiver_index, 4);
+    for (int i = 12; i < WG_RESP_SIZE; i++)
+        buf[i] = (uint8_t)(i ^ (sender_index & 0xFF));
+}
 
 static void make_wg_transport(uint8_t *buf, uint32_t receiver_index,
                                uint64_t counter, int total_size) {
@@ -1013,6 +1025,110 @@ static void test_concurrent_handshakes(void) {
 
     for (int i = 0; i < nthreads; i++) close(args[i].fd);
     stop_proxy(proxy);
+    close(server_fd);
+}
+
+/* ---- Scenario 5b: two handshakes for different peers in one batch ----
+ *
+ * In server/reverse mode the s2c headroom is only max_s4, so any handshake with
+ * S1/S2/S3 above that is built in the transform's shared buffer. Queueing such a
+ * packet in the sendmmsg batch and then transforming the next one overwrites it
+ * before the batch is sent: with two peers rekeying at the same moment each gets
+ * the other's packet and its own handshake is lost. Here S2=15 and S4=0, so
+ * every response takes that path. */
+static void test_server_handshake_batch(void) {
+    int listen_port = find_free_port();
+    int remote_port = find_free_port();
+    ASSERT(listen_port > 0);
+    ASSERT(remote_port > 0);
+
+    int server_fd = make_udp_socket(remote_port);
+    ASSERT(server_fd >= 0);
+
+    pid_t proxy = start_proxy("server", listen_port, remote_port);
+    ASSERT(proxy > 0);
+
+    struct sockaddr_in proxy_addr = make_addr(listen_port);
+    const uint32_t idx_a = 0x7100, idx_b = 0x7200;
+    int fd_a = make_client_socket();
+    int fd_b = make_client_socket();
+    ASSERT(fd_a >= 0 && fd_b >= 0);
+
+    /* Both clients establish a session so the proxy can route responses. */
+    uint8_t awg_init[TEST_S1 + WG_INIT_SIZE];
+    make_awg_init(awg_init, idx_a);
+    sendto(fd_a, awg_init, sizeof(awg_init), 0,
+           (struct sockaddr *)&proxy_addr, sizeof(proxy_addr));
+    make_awg_init(awg_init, idx_b);
+    sendto(fd_b, awg_init, sizeof(awg_init), 0,
+           (struct sockaddr *)&proxy_addr, sizeof(proxy_addr));
+    usleep(300000);
+
+    /* Learn the proxy's source address as the server sees it, then drain. */
+    struct sockaddr_in proxy_remote_addr;
+    memset(&proxy_remote_addr, 0, sizeof(proxy_remote_addr));
+    {
+        uint8_t tmp[2048];
+        struct sockaddr_in from;
+        socklen_t fromlen = sizeof(from);
+        int got = 0;
+        for (int i = 0; i < 2 * (TEST_JC + 2); i++) {
+            ssize_t n = recvfrom(server_fd, tmp, sizeof(tmp), MSG_DONTWAIT,
+                                 (struct sockaddr *)&from, &fromlen);
+            if (n > 0) { proxy_remote_addr = from; got = 1; }
+        }
+        ASSERT(got);
+    }
+
+    /* Rounds of two back-to-back responses, one per peer. Sending them without a
+     * gap is what puts both in the same recvmmsg batch; several rounds cover the
+     * case where the kernel splits a pair. */
+    const int rounds = 25;
+    int delivered_a = 0, delivered_b = 0, crossed = 0;
+
+    for (int r = 0; r < rounds; r++) {
+        uint32_t mark_a = 0xA0000000u + (uint32_t)r;
+        uint32_t mark_b = 0xB0000000u + (uint32_t)r;
+        uint8_t resp[WG_RESP_SIZE];
+
+        make_wg_response(resp, mark_a, idx_a);
+        sendto(server_fd, resp, sizeof(resp), 0,
+               (struct sockaddr *)&proxy_remote_addr, sizeof(proxy_remote_addr));
+        make_wg_response(resp, mark_b, idx_b);
+        sendto(server_fd, resp, sizeof(resp), 0,
+               (struct sockaddr *)&proxy_remote_addr, sizeof(proxy_remote_addr));
+
+        /* Each client must get its own response: same size, H2 type, and the
+         * marker this round put in that peer's packet. */
+        struct { int fd; uint32_t mine, theirs; int *hit; } peers[2] = {
+            { fd_a, mark_a, mark_b, &delivered_a },
+            { fd_b, mark_b, mark_a, &delivered_b },
+        };
+        for (int p = 0; p < 2; p++) {
+            uint8_t rbuf[2048];
+            for (int attempt = 0; attempt < 4; attempt++) {
+                int n = recv_one(peers[p].fd, rbuf, sizeof(rbuf), 300);
+                if (n != TEST_S2 + WG_RESP_SIZE) continue;
+                uint32_t h, mark;
+                memcpy(&h, rbuf + TEST_S2, 4);
+                if (h != TEST_H2) continue;
+                memcpy(&mark, rbuf + TEST_S2 + 4, 4);
+                if (mark == peers[p].mine) (*peers[p].hit)++;
+                else if (mark == peers[p].theirs) crossed++;
+                break;
+            }
+        }
+    }
+
+    fprintf(stderr, "          (own: %d+%d/%d, crossed: %d)\n",
+            delivered_a, delivered_b, 2 * rounds, crossed);
+
+    ASSERT_EQ(crossed, 0);
+    ASSERT(delivered_a + delivered_b >= 2 * rounds * 9 / 10);
+
+    stop_proxy(proxy);
+    close(fd_a);
+    close(fd_b);
     close(server_fd);
 }
 
@@ -2823,6 +2939,7 @@ int main(void) {
     RUN_TEST(server_multiclient);
     RUN_TEST(server_rekey);
     RUN_TEST(concurrent_handshakes);
+    RUN_TEST(server_handshake_batch);
     RUN_TEST(scale);
     RUN_TEST(gso_connected);
     RUN_TEST(gro_bidirectional);

--- a/src/test_transform.c
+++ b/src/test_transform.c
@@ -1548,6 +1548,38 @@ static void test_hp_padding_is_not_a_clone_of_caller_prng(void) {
     ASSERT(memcmp(out, next, CHACHA20_NONCE_SIZE) != 0);
 }
 
+/* The padding is the one field an observer sees raw, so it must not be the
+ * output of a generator whose state it reveals. xorshift64 was exactly that:
+ * the second 8 bytes are one step of the generator applied to the first 8, so
+ * a censor confirmed awg-proxy from a single packet. */
+static void test_padding_is_not_a_prng_chain(void) {
+    awg_config_t cfg = make_v3_config();
+    fastrand_t rng;
+    fastrand_init(&rng, 0x5EED5EED5EED5EEDull);
+
+    for (int i = 0; i < 16; i++) {
+        uint8_t buf[AWG_PACKET_BUF_SIZE];
+        int dataoff = AWG_PACKET_HEADROOM;
+        uint8_t *data = buf + dataoff;
+        memset(data, 0xAA, WG_INIT_SIZE);
+        write32_le(data, WG_HANDSHAKE_INIT);
+
+        int out_len = 0, sendJunk = 0;
+        uint8_t *out = transform_outbound(buf, dataoff, WG_INIT_SIZE, &cfg,
+                                          fastrand_u64(&rng), &out_len, &sendJunk);
+        ASSERT(out != NULL);
+        ASSERT(cfg.s1 >= 16);
+
+        uint64_t first;
+        memcpy(&first, out, 8);
+        uint64_t step = first;
+        step ^= step << 13;
+        step ^= step >> 7;
+        step ^= step << 17;
+        ASSERT(memcmp(out + 8, &step, 8) != 0);
+    }
+}
+
 /* Two packets drawn from the same generator must never share a nonce. */
 static void test_hp_nonce_differs_between_packets(void) {
     awg_config_t cfg = make_v3_config();
@@ -1720,7 +1752,10 @@ static void test_hp_off_matches_v2(void) {
         uint8_t *ob = transform_outbound(b, dataoff, cases[c].len, &keyed, 777, &lb, &jb);
         ASSERT_EQ(la, lb);
         ASSERT_EQ(ja, jb);
-        ASSERT_MEM_EQ(oa, ob, (size_t)la);
+        /* The padding itself is random bytes, so only the message after it can
+         * be compared — that is where a stray ChaCha20 pass would show up. */
+        int pad = la - cases[c].len;
+        ASSERT_MEM_EQ(oa + pad, ob + pad, (size_t)cases[c].len);
 
         /* And inbound agrees too */
         int ia, ib;
@@ -2115,6 +2150,7 @@ int main(void) {
     RUN_TEST(hp_roundtrip_init);
     RUN_TEST(hp_padding_is_not_a_clone_of_caller_prng);
     RUN_TEST(hp_nonce_differs_between_packets);
+    RUN_TEST(padding_is_not_a_prng_chain);
     RUN_TEST(reference_accepts_v1);
     RUN_TEST(reference_accepts_v1_5);
     RUN_TEST(reference_accepts_v2);

--- a/src/test_transform.c
+++ b/src/test_transform.c
@@ -1580,6 +1580,55 @@ static void test_padding_is_not_a_prng_chain(void) {
     }
 }
 
+/* When the caller's headroom is smaller than the padding, the transform falls
+ * back to a buffer shared by the whole thread. Two packets in a row therefore
+ * land on the same address and the first one's bytes are gone — which is why a
+ * caller that queues packets has to send such a packet immediately. The
+ * predicate is what proxy.c keys that decision on, so pin both halves. */
+static void test_shared_buf_is_reported_and_reused(void) {
+    awg_config_t cfg = make_v3_config();
+    ASSERT(cfg.s1 > 8);
+
+    uint8_t buf_a[AWG_PACKET_BUF_SIZE + AWG_PACKET_HEADROOM];
+    uint8_t buf_b[AWG_PACKET_BUF_SIZE + AWG_PACKET_HEADROOM];
+    int dataoff = 4;                       /* below S1: forces the fallback */
+    ASSERT(dataoff < cfg.s1);
+
+    memset(buf_a + dataoff, 0xA1, WG_INIT_SIZE);
+    write32_le(buf_a + dataoff, WG_HANDSHAKE_INIT);
+    memset(buf_b + dataoff, 0xB2, WG_INIT_SIZE);
+    write32_le(buf_b + dataoff, WG_HANDSHAKE_INIT);
+
+    int len_a = 0, len_b = 0, junk = 0;
+    uint8_t *out_a = transform_outbound(buf_a, dataoff, WG_INIT_SIZE, &cfg,
+                                        0x1111ull, &len_a, &junk);
+    ASSERT(out_a != NULL);
+    ASSERT(transform_is_shared_buf(out_a));
+    ASSERT_EQ(len_a, cfg.s1 + WG_INIT_SIZE);
+
+    uint8_t first[AWG_PACKET_BUF_SIZE];
+    memcpy(first, out_a, (size_t)len_a);
+
+    uint8_t *out_b = transform_outbound(buf_b, dataoff, WG_INIT_SIZE, &cfg,
+                                        0x2222ull, &len_b, &junk);
+    ASSERT(out_b != NULL);
+    ASSERT(transform_is_shared_buf(out_b));
+    ASSERT(out_a == out_b);
+    ASSERT(memcmp(first, out_a, (size_t)len_a) != 0);
+
+    /* With enough headroom the packet stays in its own buffer, so the batching
+     * path is not disturbed for the common case. */
+    uint8_t buf_c[AWG_PACKET_BUF_SIZE + AWG_PACKET_HEADROOM];
+    int roomy = AWG_PACKET_HEADROOM;
+    memset(buf_c + roomy, 0xC3, WG_INIT_SIZE);
+    write32_le(buf_c + roomy, WG_HANDSHAKE_INIT);
+    int len_c = 0;
+    uint8_t *out_c = transform_outbound(buf_c, roomy, WG_INIT_SIZE, &cfg,
+                                        0x3333ull, &len_c, &junk);
+    ASSERT(out_c != NULL);
+    ASSERT(!transform_is_shared_buf(out_c));
+}
+
 /* Two packets drawn from the same generator must never share a nonce. */
 static void test_hp_nonce_differs_between_packets(void) {
     awg_config_t cfg = make_v3_config();
@@ -2151,6 +2200,7 @@ int main(void) {
     RUN_TEST(hp_padding_is_not_a_clone_of_caller_prng);
     RUN_TEST(hp_nonce_differs_between_packets);
     RUN_TEST(padding_is_not_a_prng_chain);
+    RUN_TEST(shared_buf_is_reported_and_reused);
     RUN_TEST(reference_accepts_v1);
     RUN_TEST(reference_accepts_v1_5);
     RUN_TEST(reference_accepts_v2);

--- a/src/transform.c
+++ b/src/transform.c
@@ -2,6 +2,7 @@
 #include "blake2s.h"
 #include "chacha20.h"
 #include "fastrand.h"
+#include "csprng.h"
 #include <string.h>
 
 /* Static buffer for handshake packets when headroom is insufficient.
@@ -191,30 +192,27 @@ static inline void write32_le(uint8_t *p, uint32_t v) {
     memcpy(p, &v, 4);
 }
 
-/* Fill the S padding that precedes a message, deriving it from rand_val.
- * With header protection the first 12 bytes double as the ChaCha20 nonce, so
- * they must be fresh for every packet — fastrand is a bijection on its state,
- * which guarantees that.
+/* Fill the S padding that precedes a message.
  *
- * The seed must be mixed first. Callers pass their live PRNG state (the value
- * fastrand_u64() just returned), and fastrand_init() assigns the seed straight
- * to that same state word — so seeding directly would make this generator a
- * byte-exact clone of the caller's, and the padding here would equal the bytes
- * the caller emits next. Under v3 that means the handshake nonce reappears as
- * the very next transport packet's nonce: same key, same nonce, same counter,
- * which XORs the two protected headers into plaintext. It also gave the junk
- * packet ahead of an init the same 8-byte prefix as the init itself. */
+ * The padding goes on the wire raw, so it has to be indistinguishable from
+ * random to an observer — that is its entire job. xorshift64 is not: its output
+ * is its state, so eight observed bytes give the next eight exactly, and a
+ * censor confirms "this is awg-proxy" from a single packet. Under v3 the first
+ * 12 bytes are also the ChaCha20 nonce. amneziawg-go fills the same field with
+ * crypto/rand (device/send.go), and so do we. */
+static inline void fill_padding(uint8_t *dst, int len) {
+    csprng_bytes(dst, (size_t)len);
+}
+
+/* A cheap mixer for values the observer sees only as a consequence, not as
+ * bytes: it turns a live fastrand state word into a number that no longer
+ * equals the caller's next output. Padding no longer goes through it — that
+ * is csprng_bytes() now — but the AWG 3.1 trailer length still does. */
 static inline uint64_t mix64(uint64_t x) {
     x += 0x9E3779B97F4A7C15ull;
     x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ull;
     x = (x ^ (x >> 27)) * 0x94D049BB133111EBull;
     return x ^ (x >> 31);
-}
-
-static inline void fill_padding(uint8_t *dst, int len, uint64_t seed) {
-    fastrand_t tmp;
-    fastrand_init(&tmp, mix64(seed));
-    fastrand_fill(&tmp, dst, (size_t)len);
 }
 
 /* AWG 3.1: length of the random trailer for an outbound handshake, mirroring
@@ -237,7 +235,7 @@ static inline int append_trailer(const awg_config_t *cfg, const awg_profile_t *p
                                  uint8_t *pkt, int size, uint64_t seed) {
     int tl = trailer_len(cfg, pr, size, seed);
     if (tl > 0)
-        fill_padding(pkt + size, tl, seed ^ 0xFEED1ull);
+        fill_padding(pkt + size, tl);
     return size + tl;
 }
 
@@ -276,7 +274,7 @@ uint8_t *transform_outbound_profile(uint8_t *buf, int dataoff, int n,
                 memcpy(hs_buf + pr->s1, data, (size_t)n);
                 out = hs_buf;
             }
-            fill_padding(out, pr->s1, rand_val);
+            fill_padding(out, pr->s1);
             if (hp) chacha20_xor(cfg->hp_key, out, out + pr->s1, n);
             *out_len = append_trailer(cfg, pr, out, pr->s1 + n, rand_val);
             return out;
@@ -297,7 +295,7 @@ uint8_t *transform_outbound_profile(uint8_t *buf, int dataoff, int n,
                 memcpy(hs_buf + pr->s2, data, (size_t)n);
                 out = hs_buf;
             }
-            fill_padding(out, pr->s2, rand_val ^ 0x12345);
+            fill_padding(out, pr->s2);
             if (hp) chacha20_xor(cfg->hp_key, out, out + pr->s2, n);
             *out_len = append_trailer(cfg, pr, out, pr->s2 + n, rand_val ^ 0x12345);
             return out;
@@ -322,7 +320,7 @@ uint8_t *transform_outbound_profile(uint8_t *buf, int dataoff, int n,
                 memcpy(hs_buf + pr->s3, data, (size_t)n);
                 out = hs_buf;
             }
-            fill_padding(out, pr->s3, rand_val ^ 0x67890);
+            fill_padding(out, pr->s3);
             if (hp) chacha20_xor(cfg->hp_key, out, out + pr->s3, n);
             *out_len = append_trailer(cfg, pr, out, pr->s3 + n, rand_val ^ 0x67890);
             return out;
@@ -342,7 +340,7 @@ uint8_t *transform_outbound_profile(uint8_t *buf, int dataoff, int n,
             write32_le(data, hrange_pick(&pr->h4, rand_val));
         if (pr->s4 > 0 && dataoff >= pr->s4) {
             uint8_t *out = data - pr->s4;
-            fill_padding(out, pr->s4, rand_val ^ 0xABCDE);
+            fill_padding(out, pr->s4);
             if (hp) chacha20_xor(cfg->hp_key, out, data, AWG_HP_TRANSPORT_HDR);
             *out_len = pr->s4 + n;
             return out;

--- a/src/transform.c
+++ b/src/transform.c
@@ -9,6 +9,10 @@
  * Handshakes are rare (1-2 per connection), so static is fine. */
 static __thread uint8_t hs_buf[AWG_PACKET_BUF_SIZE];
 
+int transform_is_shared_buf(const uint8_t *p) {
+    return p >= hs_buf && p < hs_buf + sizeof(hs_buf);
+}
+
 static int hrange_overlaps(const hrange_t *a, const hrange_t *b) {
     return a->min <= b->max && b->min <= a->max;
 }

--- a/src/transform.h
+++ b/src/transform.h
@@ -244,6 +244,12 @@ uint8_t *transform_outbound_profile(uint8_t *buf, int dataoff, int n,
                                     uint64_t rand_val,
                                     int *out_len, int *sendJunk);
 
+/* True if p points into the thread-local buffer transform_outbound* falls back
+ * to when the caller's headroom is smaller than the padding. That buffer is
+ * shared by every packet of the thread, so a caller that queues packets (a
+ * sendmmsg batch) must send such a packet before transforming the next one. */
+int transform_is_shared_buf(const uint8_t *p);
+
 /* Same, on the active profile. */
 uint8_t *transform_outbound(uint8_t *buf, int dataoff, int n,
                              const awg_config_t *cfg, uint64_t rand_val,


### PR DESCRIPTION
Ветка пересобрана поверх v1.2.4. Реализацию 3.0 сверил с эталоном v3.0.3 — что шифруется целиком, что только заголовком, откуда берётся nonce, в каком порядке считается mac1: всё совпадает. Здесь три вещи, которые я нашёл поверх этого. Первые две — про то, что прокси отличим от настоящего AmneziaWG по трафику, третья — обычный баг с перемешиванием пакетов.

## 1. Паддинг выдаёт прокси по одному пакету

S1..S4 — это байты, которые дописываются перед пакетом, чтобы он не имел узнаваемой структуры. Единственное требование к ним: выглядеть случайными. Заполнялись они из `fastrand`, а это xorshift64 — генератор, у которого выход и есть его внутреннее состояние. Из этого следует неприятное: увидев первые 8 байт паддинга, следующие 8 можно посчитать точно, тремя сдвигами и XOR.

То есть наблюдателю на пути достаточно взять один UDP-пакет и проверить одно равенство. Совпало — это awg-proxy. Не эвристика, не накопление статистики, не «похоже на» — точное совпадение. У настоящего AmneziaWG там `crypto/rand` (`send.go:150,195,249,546`), и такая проверка не проходит никогда.

В транспортном fast-path хуже: паддинг всех пакетов идёт подряд из одного генератора, поэтому по одному пакету восстанавливается состояние и предсказывается паддинг всех следующих. Тела junk-пакетов заполнялись оттуда же, так что и они предсказуемы.

Под 3.0 первые 12 байт паддинга — ещё и nonce для ChaCha20. Ключ от этого не страдает и nonce не повторяется, шифрование заголовков работает как задумано. Но получается, что мы прячем заголовок под ключом, а рядом кладём поле, которое само себя выдаёт.

Проверил на стенде из этого же репозитория. Профиль v3, S4=14, 30 пингов по 1200 байт, tcpdump на прокси в сторону сервера, для каждого транспортного пакета проверяется `pad[8:14] == xorshift64(pad[0:8])[0:6]` — 48 бит, случайное совпадение исключено:

```
awg-proxy v1.2.4:                        29 из 29 предсказуемы
amneziawg-go v3.0.3, тот же профиль:      0 из 30      контроль, scripts/awg-direct.sh
awg-proxy с этой веткой:                  0 из 30
```

Контроль снят тем же сервером и тем же профилем, только без прокси в пути — значит признак ловит именно реализацию, а не настройки.

Если docker разворачивать не хочется, вот то же самое одним файлом из корня репозитория, на исходниках v1.2.4:

```c
/* cc -std=c11 -D_GNU_SOURCE -I. -o /tmp/pp padding_predictable.c \
 *    src/transform.c src/fastrand.c src/blake2s.c src/chacha20.c && /tmp/pp */
#include <stdint.h>
#include <stdio.h>
#include <string.h>
#include "src/transform.h"
#include "src/fastrand.h"

static uint64_t xorshift64(uint64_t s) {
    s ^= s << 13; s ^= s >> 7; s ^= s << 17; return s;
}
static uint64_t le64(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return v; }

int main(void) {
    static uint8_t buf[AWG_PACKET_BUF_SIZE + AWG_PACKET_HEADROOM];
    awg_config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
    cfg.s1 = 77; cfg.s2 = 41; cfg.s3 = 33; cfg.s4 = 14;   /* профиль v3 из bench */
    cfg.h1.min = 1000000; cfg.h1.max = 1000050;
    cfg.h2.min = 2000000; cfg.h2.max = 2000050;
    cfg.h3.min = 3000000; cfg.h3.max = 3000050;
    cfg.h4.min = 4000000; cfg.h4.max = 4000050;
    memset(cfg.hp_key, 0xA5, 32);
    cfg.hp_on = 1;
    config_compute(&cfg);

    int dataoff = 128;
    uint8_t *data = buf + dataoff;
    memset(data, 0x11, WG_INIT_SIZE);
    uint32_t t = WG_HANDSHAKE_INIT;
    memcpy(data, &t, 4);

    int out_len, junk;
    uint8_t *out = transform_outbound(buf, dataoff, WG_INIT_SIZE, &cfg,
                                      0x0123456789ABCDEFull, &out_len, &junk);
    uint64_t seen = le64(out), predicted = xorshift64(seen);
    printf("pad[0..8)             = %016llx\n", (unsigned long long)seen);
    printf("pad[8..16)            = %016llx\n", (unsigned long long)le64(out + 8));
    printf("xorshift64(pad[0..8)) = %016llx  -> %s\n", (unsigned long long)predicted,
           memcmp(out + 8, &predicted, 8) == 0 ? "MATCH" : "no match");
    return 0;
}
```

На v1.2.4 печатает `MATCH`:

```
pad[0..8)             = 20c0c3f0186fb288
pad[8..16)            = 423796b98a38cfed
xorshift64(pad[0..8)) = 423796b98a38cfed  -> MATCH
```

**Как чиню.** Всё, что уходит на провод сырыми байтами, теперь берётся из ядра: `getrandom(2)`, фолбэк `/dev/urandom`. Чтобы не делать syscall на каждый пакет, байты набираются в per-thread пул на 4 КБ — при S4=14 это один вызов примерно на 290 пакетов, и он не виден в замерах (цифры ниже). Выданные байты в пуле затираются, чтобы позже прочитанная память не отдала уже отправленные nonce.

`fastrand` никуда не делся и остаётся там, где на проводе видны не его байты, а следствие: выбор H-значения из диапазона и размера junk-пакета. Там его свойств хватает.

Заодно поправил, откуда `fastrand` берёт seed. Раньше `read()` из `/dev/urandom` вызывался без проверки результата, а если файл не открылся — seed брался как адрес статической структуры. В статическом non-PIE бинаре это константа, то есть контейнер без `/dev/urandom` после каждого рестарта выдавал одну и ту же последовательность.

Отдельно решил, что делать, если энтропии нет вообще. На старте — падаем с внятным сообщением. Если источник работал и пропал на ходу (здоровое ядро так себя не ведёт) — лог и `abort()`. Писать нули было бы худшим вариантом: это тот же самый предсказуемый паттерн, ради которого всё это делается, и убрать его с чужих дампов уже нельзя, а перезапуск процесса супервизором — дело поправимое.

## 2. CPS-пакеты одинаковые у всех и всегда

`cps_generate()` сеял генератор значением `counter ^ 0xDEADBEEF`, где counter — счётчик пакетов, начинающийся с нуля. Никакой энтропии. Значит первый CPS-пакет после старта побайтно одинаков при каждом запуске — и у меня, и у вас, и у любого пользователя с тем же шаблоном.

Два независимых старта прокси, профиль v3 стенда с `I1='<b 0xf1e2><r 8>'`:

```
запуск 1:  f1e2 52be06bfa79cc537
запуск 2:  f1e2 52be06bfa79cc537
```

Восемь «случайных» байт совпали. Для DPI это готовая сигнатура, которую достаточно один раз добавить в списки — причём на пакете, вся задача которого изображать посторонний протокол.

**Как чиню.** Случайные сегменты `<r N>`, `<rc N>`, `<rd N>` тоже идут из CSPRNG. Символы для `<rc>`/`<rd>` выбираются как в эталоне (`obf_randchars.go`): байт из CSPRNG и остаток от деления, а не отдельный вызов генератора на каждый символ.

## 3. Два пира, рекеящиеся одновременно, получают пакеты друг друга

Когда в буфере вызывающего не хватает места под паддинг, `transform_outbound*` строит пакет в запасном буфере, одном на поток. В reverse/server режимах headroom равен `max_s4` — обычно полтора десятка байт, а S1/S2/S3 почти всегда больше. То есть в этих режимах туда попадает **каждое** рукопожатие, а не редкий крайний случай.

Дальше `process_s2c_pkt_reverse` клал указатель на этот буфер в батч `sendmmsg` и переходил к следующему пакету, который тот же буфер и переписывал. Если в одном батче оказались рукопожатия для двух разных пиров, до `sendmmsg` доживает только второе, и уходит оно обоим. Первый пир получает чужой пакет, своё рукопожатие теряет и повторяет по таймауту. В c2s-пути флаш перед медленной веткой у вас есть, в s2c его не оказалось.

Написал сценарий в `test_stress`: два клиента, сервер шлёт пары рукопожатий подряд, каждый клиент должен получить своё. **На коде до правки — 24 перекрёстных доставки из 25 раундов, тест падает. После — 0.**

**Как чиню.** Такой пакет отправляется сразу, не через батч. Остальные, как и раньше, копятся, так что GSO и батчинг транспорта не тронуты. Проверять принадлежность буфера сравнением указателя с границами чужого массива я не стал — формально это UB и снаружи непроверяемо; вместо этого `transform.c` отдаёт предикат `transform_is_shared_buf()` рядом с самим буфером, и он же покрыт юнит-тестом.

## Тесты

- `test_csprng` — новый: пишет ровно запрошенную длину и не трогает соседние байты, две выдачи не совпадают, результат не является цепочкой xorshift, всё работает через границу пула и на запросах больше пула, у потоков независимые пулы;
- `padding_is_not_a_prng_chain` в `test_transform` — паддинг не шаг xorshift от собственных первых байт;
- два теста в `test_cps` — одинаковый counter даёт разные байты, сегмент не цепочка;
- `shared_buf_is_reported_and_reused` в `test_transform` — при нехватке headroom предикат срабатывает, два преобразования подряд дают один адрес и первый пакет затёрт; при достаточном headroom предикат молчит, то есть батчинг обычного пути не задет;
- `server_handshake_batch` в `test_stress` — функциональная проверка из пункта 3.

В `hp_off_matches_v2` пришлось сузить сравнение до сообщения после паддинга: сам паддинг теперь случайный, и его побайтное равенство между двумя конфигами больше не воспроизводится. Смысл теста — что без ключа ветка ChaCha20 не вызывается — сохранился.

## Что прогнал

Всё — на v1.2.4, после переноса ветки.

- `make test` — 168 проверок, зелено (включая ваши новые `test-state` и расширенные `test-session`/`test-stress`);
- `make test-stress` — 22 сценария; падает `scale` на 1M пакетов, но он ровно так же падает и на чистом v1.2.4 (2.17% против 2.19% потерь на loopback), это машина, а не правки;
- `bench/awg3-interop` — 52 из 53 на этой ветке; падает `happy-eyeballs` (dual-stack имя с чёрной дырой на IPv4, нет рукопожатия за 25 с), но он ровно так же падает на чистом v1.2.4 — я прогнал матрицу на обеих сборках, счёт совпал вплоть до имени сценария;
- ASan и UBSan по `csprng`/`cps`/`transform`, `gcc -fanalyzer` по `csprng.c`, `transform.c`, `cps.c`, `proxy.c` — чисто;
- пропускная способность, пять чередующихся прогонов `throughput_benchmark` на каждой сборке:

  ```
  v1.2.4:     upload 727.1 / 514.6 / 698.7 / 533.4 / 739.4   download 752.9 / 742.2 / 702.1 / 677.9 / 822.2  Мбит/с
  эта ветка:  upload 715.7 / 756.9 / 750.5 / 750.9 / 739.6   download 750.2 / 747.9 / 744.9 / 825.3 / 811.3  Мбит/с
  ```

  У эталона два прогона просели до ~520 Мбит/с с parity 69–79%, то есть разброс на этом хосте доходит до 30% и разницу в единицы процентов измерить нечем. По медиане наша сборка не медленнее (upload 750.5 против 698.7, download 750.2 против 742.2), но честнее сказать так: цену syscall этот стенд не различает. Арифметика при S4=14 — один вызов `getrandom` примерно на 290 пакетов.

## Границы

Всё снято на x86-хосте с arm64-контейнерами, на самом MikroTik я не мерил. Если для роутерного железа цена CSPRNG принципиальна, скажите — поищу способ снять цифры там, где разброс не 30%. Скрипт разбора pcap для проверки паддинга в MR не включал, чтобы не тащить python в репозиторий; выложу отдельно, если понадобится.
